### PR TITLE
MINOR: set retain to true in katib manifest, such that logs are visib…

### DIFF
--- a/hparam-tuning/minimal-mnist/katib-experiment.yaml
+++ b/hparam-tuning/minimal-mnist/katib-experiment.yaml
@@ -44,6 +44,7 @@ spec:
     collector:
       kind: StdOut
   trialTemplate:
+    retain: true
     primaryContainerName: training-container
     trialParameters:
       - name: gamma


### PR DESCRIPTION
…le in the UI

How to test:
- copy the manifest, change the image to `xeurope-west3-docker.pkg.dev/prokube-internal/prokube-customer/minimal-mnist:latest` and apply it :)