### PR TITLE
Add minimal KServe + MinIO model serving example notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Many S3 libraries use environment variables for their configuration — those ar
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `S3_ENDPOINT`. They are likely already
 available in your environment. You can also ask your admin about them.
 
+## Platform compatibility
+
+Some examples require a minimum prokube platform version. If an example is not listed, no specific version requirement is known.
+
+| Example | Min platform version | Notes |
+|---|---|---|
+| `serving/minimal-s3-model` | v1.7.0 | Requires s3creds secret with KServe support |
+
 ## Contributing
 All code contributions should go via pull requests. Make sure your code is clearly documented and that it adheres
 to established standards (e.g. PEP).

--- a/serving/minimal-s3-model/README.md
+++ b/serving/minimal-s3-model/README.md
@@ -1,0 +1,17 @@
+# Minimal KServe + MinIO Model Serving Example
+
+This example demonstrates end-to-end model serving on prokube from a MinIO bucket: training a simple sklearn model,
+uploading it to MinIO, deploying it as a KServe InferenceService, and testing it with a prediction request.
+
+**Requires prokube platform v1.7.0+.** To check your version, run the following in your notebook:
+
+```py
+!kubectl get cm -n prokube paas-version -o jsonpath='{.data.paasVersion}'
+```
+
+## What the notebook does
+
+1. Trains a small SVM classifier on the Iris dataset and serializes it with `joblib`.
+2. Uploads the model to your MinIO bucket using `s3fs`.
+3. Generates and deploys a KServe `InferenceService` manifest via `kubectl`.
+4. Tests the deployed service using both the internal cluster URL and the external URL.

--- a/serving/minimal-s3-model/minimal-s3-model.ipynb
+++ b/serving/minimal-s3-model/minimal-s3-model.ipynb
@@ -66,10 +66,26 @@
    "id": "51d4bf25-37d3-4c36-8dd2-859874d3dda7",
    "metadata": {},
    "source": [
-    "The cell below automatically sets the bucket for this experiment to `<namespace>-data` (bucket available by default in prokube deployments).\n",
-    "\n",
-    "> **💡 Tip:**  \n",
-    "> If you want to use another bucket, modify the `s3_bucket` variable in the cell below."
+    "The code cell below automatically sets the bucket for this experiment to `<namespace>-data` (bucket available by default in prokube deployments)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01e90afc-dd19-41fd-8eef-c6848bc32ac1",
+   "metadata": {},
+   "source": [
+    "<div style=\"\n",
+    "  border: 1px solid #cce5ff;\n",
+    "  background-color: #eaf4ff;\n",
+    "  padding: 12px 16px;\n",
+    "  border-radius: 8px;\n",
+    "  margin: 12px 0;\n",
+    "\">\n",
+    "  <strong>💡 Tip:</strong>\n",
+    "  <div style=\"margin-top: 6px;\">\n",
+    "    If you want to use another bucket, modify the <code>s3_bucket</code> variable in the cell below.\n",
+    "  </div>\n",
+    "</div>"
    ]
   },
   {
@@ -168,7 +184,8 @@
     "\"\"\"\n",
     "manifest_file_name = \"inferenceservice.yaml\"\n",
     "with open(manifest_file_name, \"w\") as manifest_file:\n",
-    "    manifest_file.write(inference_service_manifest)"
+    "    manifest_file.write(inference_service_manifest)\n",
+    "print(f\"InferenceService manifest saved to ./{manifest_file_name}\")"
    ]
   },
   {
@@ -209,6 +226,27 @@
     "# Get InferenceService status\n",
     "!kubectl get inferenceservice {inference_service_name} \\\n",
     "  -o 'custom-columns=NAME:.metadata.name,URL:.status.url,READY:.status.conditions[?(@.type==\"Ready\")].status'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05b3882c-3c6f-42e9-8ca6-029176a57f78",
+   "metadata": {},
+   "source": [
+    "<div style=\"\n",
+    "  border: 1px solid #cce5ff;\n",
+    "  background-color: #eaf4ff;\n",
+    "  padding: 12px 16px;\n",
+    "  border-radius: 8px;\n",
+    "  margin: 12px 0;\n",
+    "\">\n",
+    "  <span style=\"font-size: 18px;\">💡</span>\n",
+    "  <strong> Tip</strong>\n",
+    "  <div style=\"margin-top: 6px;\">\n",
+    "    To watch the model in the UI, go to the prokube central dashboard / prokube UI, \n",
+    "    open <b>Endpoints</b> (or <b>Models</b>), and search for the model name.\n",
+    "  </div>\n",
+    "</div>"
    ]
   },
   {
@@ -274,16 +312,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d83652e8-2899-49a0-85ef-4f127621e7e3",
+   "id": "c6ab2fea-3f28-457c-951d-05614072dc6e",
    "metadata": {},
    "source": [
-    "Fetch the external InferenceService URL:"
+    "Obtain the InferenceService's external URL from KServe:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d43bcde6-7bf6-4091-b88e-4e14a6f28d13",
+   "id": "23fb960c-42b4-4bba-bcc0-8dc695e76176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +345,7 @@
     "    headers={\n",
     "        \"X-Api-Key\": INFERENCE_SERVICE_API_KEY\n",
     "    },\n",
-    "    json={\"instances\": [[6.8, 2.8, 4.8, 1.4], [5.1, 3.5, 1.4, 0.2]]} # an iris instance is [sepal_length, sepal_width, petal_length, petal_width]\n",
+    "    json={\"instances\": [[6.8, 2.8, 4.8, 1.4], [5.1, 3.5, 1.4, 0.2]]}\n",
     ")\n",
     "print(response.json())"
    ]

--- a/serving/minimal-s3-model/minimal-s3-model.ipynb
+++ b/serving/minimal-s3-model/minimal-s3-model.ipynb
@@ -157,6 +157,8 @@
    "id": "ed9736de-66c0-4191-964e-6fb3535501cd",
    "metadata": {},
    "source": [
+    "KServe uses a Kubernetes custom resource called \"InferenceService\" to define a deployed model — the key field is `storageUri`, which points to where the model is stored.\n",
+    "\n",
     "Create and write the manifest for the KServe InferenceService:\n"
    ]
   },

--- a/serving/minimal-s3-model/minimal-s3-model.ipynb
+++ b/serving/minimal-s3-model/minimal-s3-model.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ef9cbd78",
+   "metadata": {},
+   "source": [
+    "# Prepare the environment for the notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3fca639-7bf9-4199-b296-bfdccabe0b96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sklearn, joblib, s3fs already come with the notebook image\n",
+    "# %pip install sklearn joblib s3fs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e7aeeac-0aeb-48cb-988f-fb2e444d1d53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INFERENCE_SERVICE_API_KEY = \"\" # If not known, ask the cluster administrator for the API Key that is used to access the deployed InferenceServices.\n",
+    "if not INFERENCE_SERVICE_API_KEY:\n",
+    "    raise RuntimeError(\"Please provide the API Key that will be used to test the deployed InferenceService\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81293c0f",
+   "metadata": {},
+   "source": [
+    "# Create a small model to be deployed as InferenceService"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d69463a-cc14-4e7e-81a1-95f7d29d60ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import svm, datasets\n",
+    "from joblib import dump"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "696e48a2-c974-4b43-9fd7-bc06f254502d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a small model with iris dataset\n",
+    "iris = datasets.load_iris()\n",
+    "clf = svm.SVC(gamma='scale')\n",
+    "clf.fit(iris.data, iris.target)\n",
+    "dump(clf, 'model.joblib')\n",
+    "print(\"Iris model file model.joblib created!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e382f93b",
+   "metadata": {},
+   "source": [
+    "# Push the created model to s3 storage (MinIO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7924d92-9812-4865-a99e-82f595e33dae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import s3fs # for uploading the created model to minio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f557ff09-cbf8-49c2-b6ad-26bb648cd458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The notebook is already setup with minio credentials for the bucket that start with <namespace>-data\n",
+    "with open(\"/var/run/secrets/kubernetes.io/serviceaccount/namespace\", \"r\") as namespace_file:\n",
+    "    namespace = namespace_file.read()\n",
+    "s3_bucket = f\"{namespace}-data\"\n",
+    "s3_model_path = f\"{s3_bucket}/minimal-kserve-example\"\n",
+    "print(f\"The created model will be uploaded to s3://{s3_model_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dad0c7e-9718-4d76-ac0a-9ba7a843ca00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload the model to MinIO\n",
+    "s3 = s3fs.S3FileSystem() # Reads the s3 credentials and endpoint from the environment variables\n",
+    "s3.put(\"model.joblib\", f\"{s3_model_path}/model.joblib\")\n",
+    "# List the bucket content to see if upload was successful\n",
+    "s3.ls(s3_model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b965d76",
+   "metadata": {},
+   "source": [
+    "# Create the InferenceService manifest that will use the uploaded model and deploy it to the cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd593707-a0f5-47e8-a65b-73e467fb2c8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the manifest for the kserve InferenceService\n",
+    "inference_service_name = \"kserve-minio-test\"\n",
+    "inference_service_manifest= \\\n",
+    "f\"\"\"\n",
+    "apiVersion: serving.kserve.io/v1beta1\n",
+    "kind: InferenceService\n",
+    "metadata:\n",
+    "  name: {inference_service_name}\n",
+    "  namespace: {namespace}\n",
+    "spec:\n",
+    "  predictor:\n",
+    "    model:\n",
+    "      modelFormat:\n",
+    "        name: sklearn\n",
+    "      storageUri: s3://{s3_model_path}/model.joblib\n",
+    "\n",
+    "\"\"\"\n",
+    "manifest_file_name=\"inferenceservice.yaml\"\n",
+    "with open(manifest_file_name, \"w\") as manifest_file:\n",
+    "    manifest_file.write(inference_service_manifest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "949bfd04-1b67-4cc2-b3fd-1a37453ab8df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use kubectl to apply the created manifest\n",
+    "# Jupyter notebook replaces {variable} with actual python value\n",
+    "!kubectl apply -f {manifest_file_name} # Apply the manifest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebb6216a-831b-481c-9500-29c4fe7c615b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl wait inferenceservice --for=condition=ready --timeout 300s --namespace {namespace} {inference_service_name} # Wait for the kserve InferenceService to be ready.\n",
+    "!kubectl get inferenceservice --namespace {namespace} {inference_service_name}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b575cb6d",
+   "metadata": {},
+   "source": [
+    "# Test the deployed InferenceService with a sample request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5ab81fc-f9b2-4dd0-b969-58a7a2236420",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Below, we use {{ and }} to escape the curly braces in the jsonpath expression so Jupyter notebook does not try to replace them with python variables\n",
+    "inference_service_url = !kubectl get inferenceservice --namespace {namespace} {inference_service_name} -o jsonpath='{{.status.url}}' \n",
+    "inference_service_url = inference_service_url[0] # Jupyter notebook shell command executions returns an array\n",
+    "print(inference_service_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce43d966-76fa-4f7a-8a4f-e085d090656d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test the deployed InferenceService.\n",
+    "# The deployed service is protected by an API Key.\n",
+    "import requests\n",
+    "response = requests.post(\n",
+    "    f\"{inference_service_url}/v1/models/{inference_service_name}:predict\",\n",
+    "    headers={\n",
+    "        \"X-Api-Key\": INFERENCE_SERVICE_API_KEY\n",
+    "    },\n",
+    "    json={\"instances\": [[6.8, 2.8, 4.8, 1.4], [5.1, 3.5, 1.4, 0.2]]} # an iris instance is [sepal_length, sepal_width, petal_length, petal_width]\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/serving/minimal-s3-model/minimal-s3-model.ipynb
+++ b/serving/minimal-s3-model/minimal-s3-model.ipynb
@@ -20,18 +20,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3e7aeeac-0aeb-48cb-988f-fb2e444d1d53",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "INFERENCE_SERVICE_API_KEY = \"\" # If not known, ask the cluster administrator for the API Key that is used to access the deployed InferenceServices.\n",
-    "if not INFERENCE_SERVICE_API_KEY:\n",
-    "    raise RuntimeError(\"Please provide the API Key that will be used to test the deployed InferenceService\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "81293c0f",
    "metadata": {},
@@ -62,7 +50,7 @@
     "clf = svm.SVC(gamma='scale')\n",
     "clf.fit(iris.data, iris.target)\n",
     "dump(clf, 'model.joblib')\n",
-    "print(\"Iris model file model.joblib created!\")"
+    "print(\"Iris model file 'model.joblib' created!\")"
    ]
   },
   {
@@ -74,13 +62,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7924d92-9812-4865-a99e-82f595e33dae",
+   "cell_type": "markdown",
+   "id": "51d4bf25-37d3-4c36-8dd2-859874d3dda7",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import s3fs # for uploading the created model to minio"
+    "The cell below automatically sets the bucket for this experiment to `<namespace>-data` (bucket available by default in prokube deployments).\n",
+    "\n",
+    "> **💡 Tip:**  \n",
+    "> If you want to use another bucket, modify the `s3_bucket` variable in the cell below."
    ]
   },
   {
@@ -90,12 +79,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The notebook is already setup with minio credentials for the bucket that start with <namespace>-data\n",
     "with open(\"/var/run/secrets/kubernetes.io/serviceaccount/namespace\", \"r\") as namespace_file:\n",
     "    namespace = namespace_file.read()\n",
     "s3_bucket = f\"{namespace}-data\"\n",
     "s3_model_path = f\"{s3_bucket}/minimal-kserve-example\"\n",
     "print(f\"The created model will be uploaded to s3://{s3_model_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "013bffab-a58d-4621-8850-9991ce19a0c7",
+   "metadata": {},
+   "source": [
+    "Initialize s3 client:"
    ]
   },
   {
@@ -105,8 +101,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Upload the model to MinIO\n",
+    "import s3fs\n",
     "s3 = s3fs.S3FileSystem() # Reads the s3 credentials and endpoint from the environment variables\n",
+    "\n",
+    "# If you want to use a different s3 instance, make sure to set \n",
+    "# s3fs.S3FileSystem(endpoint_url=<endpoint_url>, key=<key>, secret=<secret>)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c71cbc70-01cf-4ff5-a489-ca17dc2ca8b4",
+   "metadata": {},
+   "source": [
+    "Upload the model to MinIO:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "054594da-4b2c-4d11-be5a-01113bc33a40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "s3.put(\"model.joblib\", f\"{s3_model_path}/model.joblib\")\n",
     "# List the bucket content to see if upload was successful\n",
     "s3.ls(s3_model_path)"
@@ -121,13 +137,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ed9736de-66c0-4191-964e-6fb3535501cd",
+   "metadata": {},
+   "source": [
+    "Create and write the manifest for the KServe InferenceService:\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "bd593707-a0f5-47e8-a65b-73e467fb2c8c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the manifest for the kserve InferenceService\n",
     "inference_service_name = \"kserve-minio-test\"\n",
     "inference_service_manifest= \\\n",
     "f\"\"\"\n",
@@ -135,7 +158,6 @@
     "kind: InferenceService\n",
     "metadata:\n",
     "  name: {inference_service_name}\n",
-    "  namespace: {namespace}\n",
     "spec:\n",
     "  predictor:\n",
     "    model:\n",
@@ -144,9 +166,17 @@
     "      storageUri: s3://{s3_model_path}/model.joblib\n",
     "\n",
     "\"\"\"\n",
-    "manifest_file_name=\"inferenceservice.yaml\"\n",
+    "manifest_file_name = \"inferenceservice.yaml\"\n",
     "with open(manifest_file_name, \"w\") as manifest_file:\n",
     "    manifest_file.write(inference_service_manifest)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "203ee838-0ab0-4ca8-a31f-498ccd6a1428",
+   "metadata": {},
+   "source": [
+    "Use `kubectl` to deploy the created manifest:"
    ]
   },
   {
@@ -156,9 +186,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use kubectl to apply the created manifest\n",
     "# Jupyter notebook replaces {variable} with actual python value\n",
-    "!kubectl apply -f {manifest_file_name} # Apply the manifest"
+    "!kubectl apply -f {manifest_file_name}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2bc5696-03f4-403e-ac67-156062903f89",
+   "metadata": {},
+   "source": [
+    "Wait for the KServe InferenceService to be ready using `kubectl`:"
    ]
   },
   {
@@ -168,8 +205,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl wait inferenceservice --for=condition=ready --timeout 300s --namespace {namespace} {inference_service_name} # Wait for the kserve InferenceService to be ready.\n",
-    "!kubectl get inferenceservice --namespace {namespace} {inference_service_name}"
+    "!kubectl wait inferenceservice --for=condition=ready --timeout 300s {inference_service_name} && echo\n",
+    "# Get InferenceService status\n",
+    "!kubectl get inferenceservice {inference_service_name} \\\n",
+    "  -o 'custom-columns=NAME:.metadata.name,URL:.status.url,READY:.status.conditions[?(@.type==\"Ready\")].status'"
    ]
   },
   {
@@ -181,16 +220,78 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1ebe5e08-2ac6-4cfd-a76d-6a215ce22d4d",
+   "metadata": {},
+   "source": [
+    "Test using the internal URL:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5ab81fc-f9b2-4dd0-b969-58a7a2236420",
+   "id": "3527b0bc-28ac-49e9-b37c-71427c2770d6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Below, we use {{ and }} to escape the curly braces in the jsonpath expression so Jupyter notebook does not try to replace them with python variables\n",
-    "inference_service_url = !kubectl get inferenceservice --namespace {namespace} {inference_service_name} -o jsonpath='{{.status.url}}' \n",
-    "inference_service_url = inference_service_url[0] # Jupyter notebook shell command executions returns an array\n",
-    "print(inference_service_url)"
+    "import requests\n",
+    "isvc_internal_url = f\"{inference_service_name}-predictor.{namespace}\"  # KServe internal endpoint is always built like this\n",
+    "response = requests.post(\n",
+    "    f\"http://{isvc_internal_url}/v1/models/{inference_service_name}:predict\",\n",
+    "    # an iris instance is [sepal_length, sepal_width, petal_length, petal_width]\n",
+    "    json={\"instances\": [[6.8, 2.8, 4.8, 1.4], [5.1, 3.5, 1.4, 0.2]]}\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b74e3132-c54d-4c56-ad32-154bd58ad46b",
+   "metadata": {},
+   "source": [
+    "## Test using external URL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2df5cbae-f406-4c33-be90-dbb0b61cf81d",
+   "metadata": {},
+   "source": [
+    "Enter the model serving API key in the cell below. If not known, ask the cluster administrator for it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e7aeeac-0aeb-48cb-988f-fb2e444d1d53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INFERENCE_SERVICE_API_KEY = \"\"\n",
+    "if not INFERENCE_SERVICE_API_KEY:\n",
+    "    raise RuntimeError(\"Please provide the API Key that will be used to test the deployed InferenceService\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d83652e8-2899-49a0-85ef-4f127621e7e3",
+   "metadata": {},
+   "source": [
+    "Fetch the external InferenceService URL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d43bcde6-7bf6-4091-b88e-4e14a6f28d13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Below, we use {{ and }} to escape the curly braces in the jsonpath expression \n",
+    "# so Jupyter notebook does not try to replace them with python variables.\n",
+    "isvc_external_url = !kubectl get inferenceservice {inference_service_name} -o jsonpath='{{.status.url}}' \n",
+    "isvc_external_url = isvc_external_url[0]  # Jupyter notebook shell command executions returns an array\n",
+    "print(isvc_external_url)"
    ]
   },
   {
@@ -200,11 +301,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Test the deployed InferenceService.\n",
-    "# The deployed service is protected by an API Key.\n",
     "import requests\n",
     "response = requests.post(\n",
-    "    f\"{inference_service_url}/v1/models/{inference_service_name}:predict\",\n",
+    "    f\"{isvc_external_url}/v1/models/{inference_service_name}:predict\",\n",
     "    headers={\n",
     "        \"X-Api-Key\": INFERENCE_SERVICE_API_KEY\n",
     "    },\n",


### PR DESCRIPTION
I needed to test kserve getting a model from minio and realized we don't have an example for it, so I created one. Any feedback is appreciated :)

The notebook does:
* Train a simple sklearn SVM classifier on the Iris dataset and serialize it with joblib
* Upload the resulting `model.joblib` to a MinIO S3 bucket using `s3fs`
* Generate and apply a KServe `InferenceService` manifest pointing to the uploaded model
* Wait for the `InferenceService` to become ready and retrieve its URL
* Send a test prediction request to the deployed service using an API key

I hope it is not using too many jupyter notebook magic that makes it hard to understand from a datascientist perspective.