### PR TITLE
Add threshold calibration workflow to KServe KEDA autoscaling example

### DIFF
--- a/serving/kserve-keda-autoscaling/README.md
+++ b/serving/kserve-keda-autoscaling/README.md
@@ -90,7 +90,7 @@ making it a stable scaling signal.
 kubectl apply -f inference-service.yaml
 
 # 2. Wait for it to become ready
-kubectl get isvc opt-125m -w
+kubectl wait inferenceservice opt-125m --for=condition=Ready --timeout=300s
 
 # 3. Deploy the KEDA ScaledObject
 kubectl apply -f scaled-object.yaml

--- a/serving/kserve-keda-autoscaling/README.md
+++ b/serving/kserve-keda-autoscaling/README.md
@@ -77,7 +77,7 @@ making it a stable scaling signal.
 |------|-------------|
 | `inference-service.yaml` | KServe InferenceService (OPT-125M, RawDeployment mode) |
 | `scaled-object.yaml` | KEDA ScaledObject — scales on token throughput |
-| `load-generator.py` | Python load generator with presets for different scaling scenarios |
+| `load-generator.py` | Python load generator and calibration tool (see [Calibrating the Threshold](#calibrating-the-threshold)) |
 
 ## Quick Start
 
@@ -146,13 +146,13 @@ It has two presets calibrated for the opt-125m model on CPU:
 
 ```bash
 # Scale to 2 replicas (moderate load)
-python load-generator.py --mode stable-2
+python load-generator.py --mode stable-2 --url http://opt-125m-predictor/openai/v1/completions --model opt-125m
 
 # Scale to 3 replicas (heavy load)
-python load-generator.py --mode stable-3
+python load-generator.py --mode stable-3 --url http://opt-125m-predictor/openai/v1/completions --model opt-125m
 
 # Custom: pick your own concurrency and pacing
-python load-generator.py --mode custom --workers 3 --sleep 1.0
+python load-generator.py --mode custom --workers 3 --sleep 1.0 --url http://opt-125m-predictor/openai/v1/completions --model opt-125m
 ```
 
 Press `Ctrl+C` to stop the load at any time. By default the script runs for
@@ -257,6 +257,77 @@ adding a second trigger for GPU KV-cache utilization:
     metricType: AverageValue
     threshold: "0.75"
 ```
+
+## Calibrating the Threshold
+
+The `threshold` in `scaled-object.yaml` is model- and hardware-specific — there is no
+universal default. A threshold that is too low causes unnecessary scale-ups; one that is
+too high means the replica is already saturated before a new one is requested.
+
+The `load-generator.py` script has a `calibrate` mode that steps through increasing
+concurrency levels, measures token throughput and mean end-to-end latency at each level,
+and prints a table. When throughput stops growing while latency keeps rising, you have
+found the saturation point. Set your threshold to ~80% of that tok/s value to leave
+headroom for the new replica to start up.
+
+**Prerequisites:**
+- Run this against a **single replica with no other traffic**
+- Delete or pause the ScaledObject first (otherwise KEDA may scale up mid-calibration)
+
+```bash
+# 1. Remove the ScaledObject so KEDA doesn't interfere
+kubectl delete scaledobject opt-125m-scaledobject --ignore-not-found
+
+# 2. Scale to exactly 1 replica
+kubectl scale deployment opt-125m-predictor --replicas=1
+
+# 3. Run calibration from a notebook terminal (replace with your model name and service URL)
+python load-generator.py \
+  --mode calibrate \
+  --url http://opt-125m-predictor/openai/v1/completions \
+  --model opt-125m
+
+# 4. Re-apply the ScaledObject with the threshold you determined
+kubectl apply -f scaled-object.yaml
+```
+
+Example output on 2× H100 NVL with Qwen2.5-72B (FP8):
+
+```
+=== vLLM single-replica throughput calibration ===
+  URL:        http://qwen25-72b-predictor/openai/v1/completions
+  Model:      qwen25-72b
+  Metrics:    http://qwen25-72b-predictor/metrics
+  Duration:   30s per concurrency step
+  Max tokens: 200
+
+Make sure only ONE replica is running and there is no other traffic.
+The ScaledObject (if deployed) should be deleted or paused first.
+
+  Concurrency  Throughput (tok/s)     Mean latency (s)     Note
+  -----------  ------------------     ----------------     ----
+  1            310.4                  0.65
+  2            891.2                  0.82
+  4            1843.7                 1.74
+  8            2491.3                 3.21
+  16           2538.9                 6.40                 <-- plateau, saturation likely here
+
+Find the last step where throughput was still growing.
+Set your KEDA threshold to ~80% of its tok/s value.
+
+  Suggested threshold (80% of last pre-plateau rate): 1993 tok/s
+```
+
+In this example the threshold would be set to ~2000 (rounding up to a round number).
+The `threshold: "2500"` in the prokube autoscaling docs was derived from a similar run.
+
+**How this connects to the ScaledObject threshold:**
+
+With `metricType: AverageValue`, KEDA divides the total cluster-wide tok/s by the current
+replica count to get a per-replica average, then scales up when that average exceeds the
+threshold. Setting the threshold to the saturation tok/s of one replica means: "add a
+replica when the existing ones are working as hard as a single replica can sustain." The
+80% headroom ensures scale-up happens before latency actually degrades.
 
 ## References
 

--- a/serving/kserve-keda-autoscaling/README.md
+++ b/serving/kserve-keda-autoscaling/README.md
@@ -77,7 +77,8 @@ making it a stable scaling signal.
 |------|-------------|
 | `inference-service.yaml` | KServe InferenceService (OPT-125M, RawDeployment mode) |
 | `scaled-object.yaml` | KEDA ScaledObject — scales on token throughput |
-| `load-generator.py` | Python load generator and calibration tool (see [Calibrating the Threshold](#calibrating-the-threshold)) |
+| `load-generator.py` | Python load generator for sustained load modes |
+| `calibrate.py` | Throughput/latency calibration script for threshold tuning |
 
 ## Quick Start
 
@@ -264,9 +265,9 @@ The `threshold` in `scaled-object.yaml` is model- and hardware-specific — ther
 universal default. A threshold that is too low causes unnecessary scale-ups; one that is
 too high means the replica is already saturated before a new one is requested.
 
-The `load-generator.py` script has a `calibrate` mode that steps through increasing
-concurrency levels, measures token throughput and mean end-to-end latency at each level,
-and prints a table. When throughput stops growing while latency keeps rising, you have
+The `calibrate.py` script steps through increasing concurrency levels, measures token
+throughput and mean end-to-end latency at each level, and prints a table. When
+throughput stops growing while latency keeps rising, you have
 found the saturation point. Set your threshold to ~80% of that tok/s value to leave
 headroom for the new replica to start up.
 
@@ -282,8 +283,7 @@ kubectl delete scaledobject opt-125m-scaledobject --ignore-not-found
 kubectl scale deployment opt-125m-predictor --replicas=1
 
 # 3. Run calibration from a notebook terminal (replace with your model name and service URL)
-python load-generator.py \
-  --mode calibrate \
+python calibrate.py \
   --url http://opt-125m-predictor/openai/v1/completions \
   --model opt-125m
 

--- a/serving/kserve-keda-autoscaling/README.md
+++ b/serving/kserve-keda-autoscaling/README.md
@@ -291,7 +291,29 @@ python load-generator.py \
 kubectl apply -f scaled-object.yaml
 ```
 
-Example output for opt-125m on CPU (the model used in this example):
+### CPU vs GPU: why the plateau looks different
+
+On **CPU**, token throughput tends to grow linearly with concurrency. The model processes
+requests in batches, and adding more concurrent workers just increases the batch size.
+There is no hard memory ceiling that causes throughput to flatten — you can keep increasing
+concurrency indefinitely, at the cost of ever-growing latency. A clean saturation plateau
+rarely appears. The calibration tool will reach the end of its concurrency steps and
+suggest a threshold based on the highest observed rate, but that number is somewhat
+arbitrary — the model was not truly saturated.
+
+On **GPU**, VRAM is a hard limit. Once the KV cache fills up, new requests queue and are
+not batched into the current forward pass — throughput plateaus sharply while latency
+climbs steeply. This is the signal to look for. The plateau is real and the threshold
+derived from it has a clear physical meaning: "one replica is compute-saturated; bring up
+another."
+
+The `threshold: "5"` in `scaled-object.yaml` was chosen to produce visible scaling with
+opt-125m at low load for demo purposes. For production GPU deployments, use the plateau
+value from your own calibration run.
+
+### Example: opt-125m on CPU (this example's model)
+
+Real output — no plateau, as expected:
 
 ```
 === vLLM single-replica throughput calibration ===
@@ -318,17 +340,41 @@ Set your KEDA threshold to ~80% of its tok/s value.
   Suggested threshold (80% of last pre-plateau rate): 106 tok/s
 ```
 
-No plateau was detected — throughput kept growing linearly all the way to 16 concurrent
-workers. This is expected for a small model on CPU: it can always absorb more concurrency
-by queuing, so you won't see a clean saturation point. The suggestion of 106 tok/s
-(80% of 133 tok/s at 16 workers) is used as a conservative upper bound.
+Throughput kept growing linearly — no saturation point. The suggestion of 106 tok/s is a
+conservative upper bound rather than a true saturation threshold.
 
-On GPU hardware with a large model, you will typically see a clear plateau where adding
-more concurrency stops increasing throughput — that is the meaningful saturation point.
+### Example: large model on GPU (illustrative)
 
-The `threshold: "5"` in `scaled-object.yaml` was chosen to produce visible scaling with
-this small CPU model at low load. For your own deployment, run the calibration on the
-actual hardware and use the suggested threshold as your starting point.
+The output below is illustrative — actual numbers depend on the model, GPU, and request
+pattern. This is what to look for: throughput grows quickly at low concurrency, then
+flattens while latency climbs, producing a clear plateau marker.
+
+```
+=== vLLM single-replica throughput calibration ===
+  URL:        http://llama3-8b-predictor/openai/v1/completions
+  Model:      llama3-8b
+  Metrics:    http://llama3-8b-predictor/metrics
+  Duration:   30s per concurrency step
+  Max tokens: 200
+
+Make sure only ONE replica is running and there is no other traffic.
+The ScaledObject (if deployed) should be deleted or paused first.
+
+  Concurrency  Throughput (tok/s)     Mean latency (s)     Note
+  -----------  ------------------     ----------------     ----
+  1            480.2                  0.41
+  2            921.7                  0.43
+  4            1738.4                 0.46
+  8            2190.5                 0.73
+  16           2281.3                 1.44                 <-- plateau, saturation likely here
+
+Find the last step where throughput was still growing.
+Set your KEDA threshold to ~80% of its tok/s value.
+
+  Suggested threshold (80% of last pre-plateau rate): 1752 tok/s
+```
+
+In this example the threshold would be set to ~1750 (or round to 2000 for comfort margin).
 
 **How this connects to the ScaledObject threshold:**
 

--- a/serving/kserve-keda-autoscaling/README.md
+++ b/serving/kserve-keda-autoscaling/README.md
@@ -291,13 +291,13 @@ python load-generator.py \
 kubectl apply -f scaled-object.yaml
 ```
 
-Example output on 2× H100 NVL with Qwen2.5-72B (FP8):
+Example output for opt-125m on CPU (the model used in this example):
 
 ```
 === vLLM single-replica throughput calibration ===
-  URL:        http://qwen25-72b-predictor/openai/v1/completions
-  Model:      qwen25-72b
-  Metrics:    http://qwen25-72b-predictor/metrics
+  URL:        http://opt-125m-predictor/openai/v1/completions
+  Model:      opt-125m
+  Metrics:    http://opt-125m-predictor/metrics
   Duration:   30s per concurrency step
   Max tokens: 200
 
@@ -306,20 +306,29 @@ The ScaledObject (if deployed) should be deleted or paused first.
 
   Concurrency  Throughput (tok/s)     Mean latency (s)     Note
   -----------  ------------------     ----------------     ----
-  1            310.4                  0.65
-  2            891.2                  0.82
-  4            1843.7                 1.74
-  8            2491.3                 3.21
-  16           2538.9                 6.40                 <-- plateau, saturation likely here
+  1            20.1                   6.06
+  2            35.6                   9.75
+  4            56.6                   9.03
+  8            81.6                   14.25
+  16           133.1                  13.71
 
 Find the last step where throughput was still growing.
 Set your KEDA threshold to ~80% of its tok/s value.
 
-  Suggested threshold (80% of last pre-plateau rate): 1993 tok/s
+  Suggested threshold (80% of last pre-plateau rate): 106 tok/s
 ```
 
-In this example the threshold would be set to ~2000 (rounding up to a round number).
-The `threshold: "2500"` in the prokube autoscaling docs was derived from a similar run.
+No plateau was detected — throughput kept growing linearly all the way to 16 concurrent
+workers. This is expected for a small model on CPU: it can always absorb more concurrency
+by queuing, so you won't see a clean saturation point. The suggestion of 106 tok/s
+(80% of 133 tok/s at 16 workers) is used as a conservative upper bound.
+
+On GPU hardware with a large model, you will typically see a clear plateau where adding
+more concurrency stops increasing throughput — that is the meaningful saturation point.
+
+The `threshold: "5"` in `scaled-object.yaml` was chosen to produce visible scaling with
+this small CPU model at low load. For your own deployment, run the calibration on the
+actual hardware and use the suggested threshold as your starting point.
 
 **How this connects to the ScaledObject threshold:**
 

--- a/serving/kserve-keda-autoscaling/README.md
+++ b/serving/kserve-keda-autoscaling/README.md
@@ -291,98 +291,16 @@ python load-generator.py \
 kubectl apply -f scaled-object.yaml
 ```
 
-### CPU vs GPU: why the plateau looks different
+### CPU vs GPU: what to expect
 
-On **CPU**, token throughput tends to grow linearly with concurrency. The model processes
-requests in batches, and adding more concurrent workers just increases the batch size.
-There is no hard memory ceiling that causes throughput to flatten — you can keep increasing
-concurrency indefinitely, at the cost of ever-growing latency. A clean saturation plateau
-rarely appears. The calibration tool will reach the end of its concurrency steps and
-suggest a threshold based on the highest observed rate, but that number is somewhat
-arbitrary — the model was not truly saturated.
+On **GPU**, throughput plateaus sharply once the KV cache fills — the tool will detect this
+as a clear saturation point. On **CPU**, there is no hard memory ceiling, so throughput
+tends to grow linearly with concurrency and the tool may not find a clean plateau. In that
+case, use the suggested value as a conservative starting point and adjust based on observed
+latency.
 
-On **GPU**, VRAM is a hard limit. Once the KV cache fills up, new requests queue and are
-not batched into the current forward pass — throughput plateaus sharply while latency
-climbs steeply. This is the signal to look for. The plateau is real and the threshold
-derived from it has a clear physical meaning: "one replica is compute-saturated; bring up
-another."
-
-The `threshold: "5"` in `scaled-object.yaml` was chosen to produce visible scaling with
-opt-125m at low load for demo purposes. For production GPU deployments, use the plateau
-value from your own calibration run.
-
-### Example: opt-125m on CPU (this example's model)
-
-Real output — no plateau, as expected:
-
-```
-=== vLLM single-replica throughput calibration ===
-  URL:        http://opt-125m-predictor/openai/v1/completions
-  Model:      opt-125m
-  Metrics:    http://opt-125m-predictor/metrics
-  Duration:   30s per concurrency step
-  Max tokens: 200
-
-Make sure only ONE replica is running and there is no other traffic.
-The ScaledObject (if deployed) should be deleted or paused first.
-
-  Concurrency  Throughput (tok/s)     Mean latency (s)     Note
-  -----------  ------------------     ----------------     ----
-  1            20.1                   6.06
-  2            35.6                   9.75
-  4            56.6                   9.03
-  8            81.6                   14.25
-  16           133.1                  13.71
-
-Find the last step where throughput was still growing.
-Set your KEDA threshold to ~80% of its tok/s value.
-
-  Suggested threshold (80% of last pre-plateau rate): 106 tok/s
-```
-
-Throughput kept growing linearly — no saturation point. The suggestion of 106 tok/s is a
-conservative upper bound rather than a true saturation threshold.
-
-### Example: large model on GPU (illustrative)
-
-The output below is illustrative — actual numbers depend on the model, GPU, and request
-pattern. This is what to look for: throughput grows quickly at low concurrency, then
-flattens while latency climbs, producing a clear plateau marker.
-
-```
-=== vLLM single-replica throughput calibration ===
-  URL:        http://llama3-8b-predictor/openai/v1/completions
-  Model:      llama3-8b
-  Metrics:    http://llama3-8b-predictor/metrics
-  Duration:   30s per concurrency step
-  Max tokens: 200
-
-Make sure only ONE replica is running and there is no other traffic.
-The ScaledObject (if deployed) should be deleted or paused first.
-
-  Concurrency  Throughput (tok/s)     Mean latency (s)     Note
-  -----------  ------------------     ----------------     ----
-  1            480.2                  0.41
-  2            921.7                  0.43
-  4            1738.4                 0.46
-  8            2190.5                 0.73
-  16           2281.3                 1.44                 <-- plateau, saturation likely here
-
-Find the last step where throughput was still growing.
-Set your KEDA threshold to ~80% of its tok/s value.
-
-  Suggested threshold (80% of last pre-plateau rate): 1752 tok/s
-```
-
-In this example the threshold would be set to ~1750 (or round to 2000 for comfort margin).
-
-**How this connects to the ScaledObject threshold:**
-
-With `metricType: AverageValue`, KEDA divides the total cluster-wide tok/s by the current
-replica count to get a per-replica average, then scales up when that average exceeds the
-threshold. Setting the threshold to the saturation tok/s of one replica means: "add a
-replica when the existing ones are working as hard as a single replica can sustain." The
-80% headroom ensures scale-up happens before latency actually degrades.
+The `threshold: "5"` in `scaled-object.yaml` is a demo value chosen for opt-125m on CPU.
+For production GPU deployments, use the plateau value from your own calibration run.
 
 ## References
 

--- a/serving/kserve-keda-autoscaling/calibrate.py
+++ b/serving/kserve-keda-autoscaling/calibrate.py
@@ -84,21 +84,33 @@ def fetch_metrics(metrics_url: str) -> str:
         return ""
 
 
-def parse_metric(metrics_text: str, prefix: str) -> float:
+def parse_metric(metrics_text: str, metric_name: str) -> float:
+    """Sum all samples whose metric name (before any '{') matches metric_name.
+
+    Handles both labeled (metric{label="v"} 1.0) and unlabeled (metric 1.0)
+    forms, and correctly aggregates across multiple label combinations.
+    """
+    total = 0.0
     for line in metrics_text.splitlines():
-        if line.startswith(prefix) and not line.startswith("# "):
-            try:
-                return float(line.split()[-1])
-            except ValueError:
-                pass
-    return 0.0
+        if not line or line.startswith("#"):
+            continue
+        sample, *rest = line.split()
+        if not rest:
+            continue
+        if sample.split("{", 1)[0] != metric_name:
+            continue
+        try:
+            total += float(rest[-1])
+        except ValueError:
+            pass
+    return total
 
 
 def snapshot_metrics(metrics_url: str) -> dict:
     text = fetch_metrics(metrics_url)
     return {
-        "latency_count": parse_metric(text, "vllm:e2e_request_latency_seconds_count{"),
-        "latency_sum": parse_metric(text, "vllm:e2e_request_latency_seconds_sum{"),
+        "latency_count": parse_metric(text, "vllm:e2e_request_latency_seconds_count"),
+        "latency_sum": parse_metric(text, "vllm:e2e_request_latency_seconds_sum"),
     }
 
 

--- a/serving/kserve-keda-autoscaling/calibrate.py
+++ b/serving/kserve-keda-autoscaling/calibrate.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Calibrate KEDA token-throughput threshold for vLLM on a single replica.
+
+This script steps through increasing concurrency, measures throughput and mean
+end-to-end latency from vLLM metrics, and suggests a threshold at ~80% of the
+last pre-plateau throughput.
+
+Usage (run from a notebook terminal inside the cluster):
+    python calibrate.py --url http://my-model-predictor/openai/v1/completions --model my-model
+
+Press Ctrl+C to stop at any time.
+"""
+
+import argparse
+import json
+import math
+import threading
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+DEFAULT_STEPS = [1, 2, 4, 8, 16]
+DEFAULT_STEP_DURATION = 30
+
+DEFAULT_URL = "http://opt-125m-predictor/openai/v1/completions"
+DEFAULT_MODEL = "opt-125m"
+DEFAULT_MAX_TOKENS = 200
+DEFAULT_PROMPT = (
+    "Write a long detailed story about a dragon who discovers a hidden kingdom"
+)
+
+
+def send_request(url: str, model: str, prompt: str, max_tokens: int) -> dict | None:
+    payload = json.dumps(
+        {
+            "model": model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return None
+
+
+def worker_loop(
+    url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    stop: threading.Event,
+    totals: dict,
+    lock: threading.Lock,
+) -> None:
+    while not stop.is_set():
+        result = send_request(url, model, prompt, max_tokens)
+        with lock:
+            if result and "usage" in result:
+                totals["tokens"] += result["usage"].get("total_tokens", 0)
+            else:
+                totals["errors"] += 1
+
+
+def metrics_url_from_completions_url(completions_url: str) -> str:
+    parsed = urlparse(completions_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{base}/metrics"
+
+
+def fetch_metrics(metrics_url: str) -> str:
+    try:
+        with urllib.request.urlopen(metrics_url, timeout=10) as resp:
+            return resp.read().decode("utf-8")
+    except (urllib.error.URLError, OSError):
+        return ""
+
+
+def parse_metric(metrics_text: str, prefix: str) -> float:
+    for line in metrics_text.splitlines():
+        if line.startswith(prefix) and not line.startswith("# "):
+            try:
+                return float(line.split()[-1])
+            except ValueError:
+                pass
+    return 0.0
+
+
+def snapshot_metrics(metrics_url: str) -> dict:
+    text = fetch_metrics(metrics_url)
+    return {
+        "latency_count": parse_metric(text, "vllm:e2e_request_latency_seconds_count{"),
+        "latency_sum": parse_metric(text, "vllm:e2e_request_latency_seconds_sum{"),
+    }
+
+
+def run_calibration(args: argparse.Namespace) -> None:
+    metrics_url = metrics_url_from_completions_url(args.url)
+
+    print("=== vLLM single-replica throughput calibration ===")
+    print(f"  URL:        {args.url}")
+    print(f"  Model:      {args.model}")
+    print(f"  Metrics:    {metrics_url}")
+    print(f"  Duration:   {DEFAULT_STEP_DURATION}s per concurrency step")
+    print(f"  Max tokens: {args.max_tokens}")
+    print()
+    print("Make sure only ONE replica is running and there is no other traffic.")
+    print("The ScaledObject (if deployed) should be deleted or paused first.")
+    print()
+
+    if not fetch_metrics(metrics_url):
+        print(f"ERROR: could not reach metrics endpoint at {metrics_url}")
+        print(
+            "Check that the service URL is correct and reachable from this pod/notebook."
+        )
+        return
+
+    print(
+        f"  {'Concurrency':<12} {'Throughput (tok/s)':<22} {'Mean latency (s)':<20} Note"
+    )
+    print(
+        f"  {'-----------':<12} {'------------------':<22} {'----------------':<20} ----"
+    )
+
+    prev_rate = 0.0
+    best_rate = 0.0
+
+    try:
+        for concurrency in DEFAULT_STEPS:
+            snap_before = snapshot_metrics(metrics_url)
+            t0 = time.time()
+
+            stop = threading.Event()
+            totals = {"tokens": 0, "errors": 0}
+            lock = threading.Lock()
+            threads = []
+
+            for _ in range(concurrency):
+                t = threading.Thread(
+                    target=worker_loop,
+                    args=(
+                        args.url,
+                        args.model,
+                        args.prompt,
+                        args.max_tokens,
+                        stop,
+                        totals,
+                        lock,
+                    ),
+                    daemon=True,
+                )
+                t.start()
+                threads.append(t)
+
+            try:
+                stop.wait(timeout=DEFAULT_STEP_DURATION)
+            except KeyboardInterrupt:
+                print("\nInterrupted — stopping current step.")
+                stop.set()
+                for t in threads:
+                    t.join(timeout=10)
+                raise
+
+            stop.set()
+            for t in threads:
+                t.join(timeout=10)
+
+            elapsed = time.time() - t0
+            snap_after = snapshot_metrics(metrics_url)
+
+            with lock:
+                step_tokens = totals["tokens"]
+                step_errors = totals["errors"]
+
+            rate = step_tokens / elapsed if elapsed > 0 else 0.0
+
+            delta_count = snap_after["latency_count"] - snap_before["latency_count"]
+            delta_sum = snap_after["latency_sum"] - snap_before["latency_sum"]
+            mean_lat = f"{delta_sum / delta_count:.2f}" if delta_count > 0 else "n/a"
+
+            note = ""
+            plateau = prev_rate > 0 and (rate - prev_rate) / prev_rate < 0.15
+            if plateau:
+                note = "<-- plateau, saturation likely here"
+            else:
+                best_rate = rate
+
+            err_note = f" ({step_errors} errors)" if step_errors else ""
+            print(f"  {concurrency:<12} {rate:<22.1f} {mean_lat:<20} {note}{err_note}")
+            prev_rate = rate
+
+            if plateau and concurrency >= 4:
+                break
+
+    except KeyboardInterrupt:
+        print()
+
+    print()
+    print("Find the last step where throughput was still growing.")
+    print("Set your KEDA threshold to ~80% of its tok/s value.")
+    print()
+    threshold_suggestion = math.floor(best_rate * 0.8) if best_rate > 0 else "?"
+    print(
+        f"  Suggested threshold (80% of last pre-plateau rate): {threshold_suggestion} tok/s"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Calibrate KEDA threshold from vLLM throughput plateau"
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help=f"Completions endpoint URL (default: {DEFAULT_URL})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Model name to use in requests (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=DEFAULT_MAX_TOKENS,
+        help=f"Max tokens per request (default: {DEFAULT_MAX_TOKENS})",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=DEFAULT_PROMPT,
+        help="Prompt text",
+    )
+    args = parser.parse_args()
+    run_calibration(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/serving/kserve-keda-autoscaling/calibrate.py
+++ b/serving/kserve-keda-autoscaling/calibrate.py
@@ -32,6 +32,7 @@ DEFAULT_PROMPT = (
 
 
 def send_request(url: str, model: str, prompt: str, max_tokens: int) -> dict | None:
+    """Send a single completion request and return the parsed JSON response, or None on error."""
     payload = json.dumps(
         {
             "model": model,
@@ -61,6 +62,7 @@ def worker_loop(
     totals: dict,
     lock: threading.Lock,
 ) -> None:
+    """Continuously send requests until stop is set, updating totals with token count and errors."""
     while not stop.is_set():
         result = send_request(url, model, prompt, max_tokens)
         with lock:
@@ -71,11 +73,13 @@ def worker_loop(
 
 
 def metrics_url_from_completions_url(completions_url: str) -> str:
+    """Derive the metrics endpoint URL from the completions endpoint URL."""
     parsed = urlparse(completions_url)
     return f"{parsed.scheme}://{parsed.netloc}/metrics"
 
 
 def fetch_metrics(metrics_url: str) -> str:
+    """Fetch the raw text from the metrics endpoint, or return an empty string on error."""
     try:
         with urllib.request.urlopen(metrics_url, timeout=10) as resp:
             return resp.read().decode("utf-8")
@@ -107,6 +111,7 @@ def parse_metric(metrics_text: str, metric_name: str) -> float:
 
 
 def snapshot_metrics(metrics_url: str) -> dict:
+    """Fetch and parse the relevant metrics, returning a dict with latency count and sum."""
     text = fetch_metrics(metrics_url)
     return {
         "latency_count": parse_metric(text, "vllm:e2e_request_latency_seconds_count"),
@@ -115,6 +120,7 @@ def snapshot_metrics(metrics_url: str) -> dict:
 
 
 def run_calibration(args: argparse.Namespace) -> None:
+    """Run the calibration process with the given arguments."""
     metrics_url = metrics_url_from_completions_url(args.url)
 
     print("=== vLLM single-replica throughput calibration ===")

--- a/serving/kserve-keda-autoscaling/calibrate.py
+++ b/serving/kserve-keda-autoscaling/calibrate.py
@@ -72,15 +72,15 @@ def worker_loop(
 
 def metrics_url_from_completions_url(completions_url: str) -> str:
     parsed = urlparse(completions_url)
-    base = f"{parsed.scheme}://{parsed.netloc}"
-    return f"{base}/metrics"
+    return f"{parsed.scheme}://{parsed.netloc}/metrics"
 
 
 def fetch_metrics(metrics_url: str) -> str:
     try:
         with urllib.request.urlopen(metrics_url, timeout=10) as resp:
             return resp.read().decode("utf-8")
-    except (urllib.error.URLError, OSError):
+    except (urllib.error.URLError, OSError) as e:
+        print(f"WARNING: could not fetch metrics from {metrics_url}: {e}")
         return ""
 
 

--- a/serving/kserve-keda-autoscaling/load-generator.py
+++ b/serving/kserve-keda-autoscaling/load-generator.py
@@ -294,7 +294,11 @@ def run_calibrate(args: argparse.Namespace) -> None:
         delta_sum = snap_after["latency_sum"] - snap_before["latency_sum"]
         mean_lat = f"{delta_sum / delta_count:.2f}" if delta_count > 0 else "n/a"
 
-        # Flag plateau: throughput grew less than 15% despite adding concurrency
+        # Flag plateau: throughput grew less than 15% despite doubling concurrency.
+        # 15% is deliberately conservative — on GPU the plateau is usually near-zero
+        # growth, so a higher threshold would still catch it.  On CPU, sub-linear
+        # growth at high concurrency (scheduling overhead, Amdahl's law) can trigger
+        # a false plateau; the `concurrency >= 4` guard on early exit mitigates this.
         note = ""
         plateau = prev_rate > 0 and (rate - prev_rate) / prev_rate < 0.15
         if plateau:

--- a/serving/kserve-keda-autoscaling/load-generator.py
+++ b/serving/kserve-keda-autoscaling/load-generator.py
@@ -93,7 +93,6 @@ def send_request(url: str, model: str, prompt: str, max_tokens: int) -> dict | N
 
 
 def worker_loop(
-    worker_id: int,
     url: str,
     model: str,
     prompt: str,
@@ -238,7 +237,6 @@ def main():
         t = threading.Thread(
             target=worker_loop,
             args=(
-                i,
                 args.url,
                 args.model,
                 args.prompt,

--- a/serving/kserve-keda-autoscaling/load-generator.py
+++ b/serving/kserve-keda-autoscaling/load-generator.py
@@ -3,9 +3,12 @@
 
 Modes:
 
-  stable-2   - Sustained moderate load (~8 tok/s) that scales to 2 replicas and holds
-  stable-3   - Sustained heavy load (~22 tok/s) that scales to 3 replicas and holds
+  stable-2   - Sustained moderate load (~8 tok/s*) that scales to 2 replicas and holds
+  stable-3   - Sustained heavy load (~22 tok/s*) that scales to 3 replicas and holds
   custom     - Specify your own --workers and --sleep values
+
+* Rates are calibrated for opt-125m on CPU with the default prompt and max-tokens.
+  Use --mode custom with your own --workers/--sleep for other models.
 
 Usage (run from a notebook terminal inside the cluster):
     python load-generator.py --mode stable-2

--- a/serving/kserve-keda-autoscaling/load-generator.py
+++ b/serving/kserve-keda-autoscaling/load-generator.py
@@ -1,34 +1,27 @@
 #!/usr/bin/env python3
-"""
-Load generator for vLLM-based KServe InferenceService autoscaling demos.
+"""Load generator for vLLM-based KServe InferenceService autoscaling demos.
 
 Modes:
 
   stable-2   - Sustained moderate load (~8 tok/s) that scales to 2 replicas and holds
   stable-3   - Sustained heavy load (~22 tok/s) that scales to 3 replicas and holds
   custom     - Specify your own --workers and --sleep values
-  calibrate  - Step through increasing concurrency levels and print a throughput/latency
-               table. Use this to find the saturation point for your model and hardware,
-               then set the KEDA threshold to ~80% of that value.
 
 Usage (run from a notebook terminal inside the cluster):
     python load-generator.py --mode stable-2
     python load-generator.py --mode stable-3 --duration 300
     python load-generator.py --mode custom --workers 3 --sleep 1.0
-    python load-generator.py --mode calibrate --url http://my-model-predictor/openai/v1/completions --model my-model
 
 Press Ctrl+C to stop at any time.
 """
 
 import argparse
 import json
-import math
 import signal
 import threading
 import time
 import urllib.request
 import urllib.error
-from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # Preset configurations
@@ -56,10 +49,6 @@ PRESETS = {
     "stable-2": {"workers": 1, "sleep": 8.0},
     "stable-3": {"workers": 2, "sleep": 2.0},
 }
-
-# Default concurrency steps for calibrate mode (doubles each time)
-DEFAULT_CALIBRATE_STEPS = [1, 2, 4, 8, 16]
-DEFAULT_CALIBRATE_STEP_DURATION = 30  # seconds per concurrency level
 
 # Default model endpoint (Kubernetes service DNS name in RawDeployment mode)
 DEFAULT_URL = "http://opt-125m-predictor/openai/v1/completions"
@@ -110,21 +99,12 @@ def worker_loop(
     prompt: str,
     max_tokens: int,
     sleep_sec: float,
-    local_stop: threading.Event | None = None,
+    stop: threading.Event,
 ):
-    """Continuously send requests with a sleep between each.
-
-    Stops when stop_event or local_stop (if given) is set.
-    In load generation modes, updates the global stats counters.
-    In calibrate mode, returns per-step counts via the return value of each
-    call — but since this runs in a thread, results are collected via the
-    shared calibrate_step_* counters instead.
-    """
+    """Continuously send requests with a sleep between each."""
     global total_requests, total_tokens, total_errors
 
-    stopper = local_stop if local_stop is not None else stop_event
-
-    while not stopper.is_set() and not stop_event.is_set():
+    while not stop.is_set():
         result = send_request(url, model, prompt, max_tokens)
 
         with stats_lock:
@@ -134,8 +114,8 @@ def worker_loop(
             else:
                 total_errors += 1
 
-        if sleep_sec > 0 and not stopper.is_set():
-            stopper.wait(timeout=sleep_sec)
+        if sleep_sec > 0 and not stop.is_set():
+            stop.wait(timeout=sleep_sec)
 
 
 def print_stats():
@@ -156,175 +136,6 @@ def print_stats():
 
 
 # ---------------------------------------------------------------------------
-# Calibrate mode helpers
-# ---------------------------------------------------------------------------
-
-
-def metrics_url_from_completions_url(completions_url: str) -> str:
-    """Derive the /metrics URL from the completions endpoint URL.
-
-    e.g. http://opt-125m-predictor/openai/v1/completions
-      -> http://opt-125m-predictor/metrics
-    """
-    parsed = urlparse(completions_url)
-    base = f"{parsed.scheme}://{parsed.netloc}"
-    return f"{base}/metrics"
-
-
-def fetch_metrics(metrics_url: str) -> str:
-    """Fetch the raw Prometheus metrics text from the vLLM endpoint."""
-    try:
-        with urllib.request.urlopen(metrics_url, timeout=10) as resp:
-            return resp.read().decode("utf-8")
-    except (urllib.error.URLError, OSError):
-        return ""
-
-
-def parse_metric(metrics_text: str, prefix: str) -> float:
-    """Extract the value of the first metric line starting with prefix."""
-    for line in metrics_text.splitlines():
-        if line.startswith(prefix) and not line.startswith("# "):
-            try:
-                return float(line.split()[-1])
-            except ValueError:
-                pass
-    return 0.0
-
-
-def snapshot_metrics(metrics_url: str) -> dict:
-    """Return a snapshot of the counters needed for calibration."""
-    text = fetch_metrics(metrics_url)
-    return {
-        "prompt_tokens": parse_metric(text, "vllm:prompt_tokens_total{"),
-        "generation_tokens": parse_metric(text, "vllm:generation_tokens_total{"),
-        "latency_count": parse_metric(text, "vllm:e2e_request_latency_seconds_count{"),
-        "latency_sum": parse_metric(text, "vllm:e2e_request_latency_seconds_sum{"),
-    }
-
-
-def run_calibrate(args: argparse.Namespace) -> None:
-    """Step through concurrency levels and print a throughput/latency table."""
-    global total_requests, total_tokens, total_errors
-
-    m_url = metrics_url_from_completions_url(args.url)
-
-    steps = DEFAULT_CALIBRATE_STEPS
-    step_duration = DEFAULT_CALIBRATE_STEP_DURATION
-
-    print("=== vLLM single-replica throughput calibration ===")
-    print(f"  URL:        {args.url}")
-    print(f"  Model:      {args.model}")
-    print(f"  Metrics:    {m_url}")
-    print(f"  Duration:   {step_duration}s per concurrency step")
-    print(f"  Max tokens: {args.max_tokens}")
-    print()
-    print("Make sure only ONE replica is running and there is no other traffic.")
-    print("The ScaledObject (if deployed) should be deleted or paused first.")
-    print()
-
-    # Verify metrics are reachable
-    test = fetch_metrics(m_url)
-    if not test:
-        print(f"ERROR: could not reach metrics endpoint at {m_url}")
-        print(
-            "Check that the service URL is correct and reachable from this pod/notebook."
-        )
-        return
-
-    print(
-        f"  {'Concurrency':<12} {'Throughput (tok/s)':<22} {'Mean latency (s)':<20} Note"
-    )
-    print(
-        f"  {'-----------':<12} {'------------------':<22} {'----------------':<20} ----"
-    )
-
-    prev_rate: float = 0.0
-    best_rate: float = 0.0  # last rate before a plateau was detected
-
-    for concurrency in steps:
-        # Snapshot before
-        snap_before = snapshot_metrics(m_url)
-        t0 = time.time()
-
-        # Run load for step_duration seconds using a per-step stop event
-        step_stop = threading.Event()
-        threads = []
-        # Reset per-step counters
-        with stats_lock:
-            total_requests = 0
-            total_tokens = 0
-            total_errors = 0
-
-        for _ in range(concurrency):
-            t = threading.Thread(
-                target=worker_loop,
-                args=(
-                    0,
-                    args.url,
-                    args.model,
-                    args.prompt,
-                    args.max_tokens,
-                    0.0,
-                    step_stop,
-                ),
-                daemon=True,
-            )
-            t.start()
-            threads.append(t)
-
-        step_stop.wait(timeout=step_duration)
-        step_stop.set()
-        for t in threads:
-            t.join(timeout=10)
-
-        elapsed = time.time() - t0
-
-        # Snapshot after (for latency delta only)
-        snap_after = snapshot_metrics(m_url)
-
-        # Throughput: derived from response bodies (exact), not /metrics counters.
-        # The global total_tokens counter was reset at step start and incremented
-        # by worker_loop for every completed request within this step.
-        with stats_lock:
-            step_tokens = total_tokens
-            step_errors = total_errors
-        rate = step_tokens / elapsed if elapsed > 0 else 0.0
-
-        delta_count = snap_after["latency_count"] - snap_before["latency_count"]
-        delta_sum = snap_after["latency_sum"] - snap_before["latency_sum"]
-        mean_lat = f"{delta_sum / delta_count:.2f}" if delta_count > 0 else "n/a"
-
-        # Flag plateau: throughput grew less than 15% despite doubling concurrency.
-        # 15% is deliberately conservative — on GPU the plateau is usually near-zero
-        # growth, so a higher threshold would still catch it.  On CPU, sub-linear
-        # growth at high concurrency (scheduling overhead, Amdahl's law) can trigger
-        # a false plateau; the `concurrency >= 4` guard on early exit mitigates this.
-        note = ""
-        plateau = prev_rate > 0 and (rate - prev_rate) / prev_rate < 0.15
-        if plateau:
-            note = "<-- plateau, saturation likely here"
-        else:
-            best_rate = rate  # still growing — update best
-
-        err_note = f" ({step_errors} errors)" if step_errors else ""
-        print(f"  {concurrency:<12} {rate:<22.1f} {mean_lat:<20} {note}{err_note}")
-        prev_rate = rate
-
-        # Stop early once clearly saturated
-        if plateau and concurrency >= 4:
-            break
-
-    print()
-    print("Find the last step where throughput was still growing.")
-    print("Set your KEDA threshold to ~80% of its tok/s value.")
-    print()
-    threshold_suggestion = math.floor(best_rate * 0.8) if best_rate > 0 else "?"
-    print(
-        f"  Suggested threshold (80% of last pre-plateau rate): {threshold_suggestion} tok/s"
-    )
-
-
-# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -333,13 +144,13 @@ def main():
     global start_time
 
     parser = argparse.ArgumentParser(
-        description="Load generator and calibration tool for KServe + KEDA autoscaling",
+        description="Load generator for KServe + KEDA autoscaling",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
     parser.add_argument(
         "--mode",
-        choices=["stable-2", "stable-3", "custom", "calibrate"],
+        choices=["stable-2", "stable-3", "custom"],
         default="stable-2",
         help="Mode to run (default: stable-2)",
     )
@@ -386,16 +197,6 @@ def main():
     args = parser.parse_args()
 
     # ---------------------------------------------------------------------------
-    # Calibrate mode — separate path, no global stat loop
-    # ---------------------------------------------------------------------------
-    if args.mode == "calibrate":
-        signal.signal(
-            signal.SIGINT, lambda s, f: (print("\nInterrupted."), stop_event.set())
-        )
-        run_calibrate(args)
-        return
-
-    # ---------------------------------------------------------------------------
     # Load generation modes
     # ---------------------------------------------------------------------------
     if args.mode == "custom":
@@ -436,7 +237,15 @@ def main():
     for i in range(workers):
         t = threading.Thread(
             target=worker_loop,
-            args=(i, args.url, args.model, args.prompt, args.max_tokens, sleep_sec),
+            args=(
+                i,
+                args.url,
+                args.model,
+                args.prompt,
+                args.max_tokens,
+                sleep_sec,
+                stop_event,
+            ),
             daemon=True,
         )
         t.start()

--- a/serving/kserve-keda-autoscaling/load-generator.py
+++ b/serving/kserve-keda-autoscaling/load-generator.py
@@ -2,28 +2,33 @@
 """
 Load generator for vLLM-based KServe InferenceService autoscaling demos.
 
-Provides two preset scenarios to demonstrate KEDA autoscaling behaviors:
+Modes:
 
-  stable-2   - Sustained moderate load that triggers a stable scale-up to 2 replicas
-  stable-3   - Sustained heavy load that triggers a stable scale-up to 3 replicas
+  stable-2   - Sustained moderate load (~8 tok/s) that scales to 2 replicas and holds
+  stable-3   - Sustained heavy load (~22 tok/s) that scales to 3 replicas and holds
+  custom     - Specify your own --workers and --sleep values
+  calibrate  - Step through increasing concurrency levels and print a throughput/latency
+               table. Use this to find the saturation point for your model and hardware,
+               then set the KEDA threshold to ~80% of that value.
 
-You can also run in 'custom' mode to specify your own concurrency and sleep values.
-
-Usage (run from a terminal with network access to the service, e.g. a Kubeflow notebook):
+Usage (run from a notebook terminal inside the cluster):
     python load-generator.py --mode stable-2
     python load-generator.py --mode stable-3 --duration 300
-    python load-generator.py --mode custom --workers 3 --sleep 2.0
+    python load-generator.py --mode custom --workers 3 --sleep 1.0
+    python load-generator.py --mode calibrate --url http://my-model-predictor/openai/v1/completions --model my-model
 
-Press Ctrl+C to stop the load at any time.
+Press Ctrl+C to stop at any time.
 """
 
 import argparse
 import json
+import math
 import signal
 import threading
 import time
 import urllib.request
 import urllib.error
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # Preset configurations
@@ -52,8 +57,13 @@ PRESETS = {
     "stable-3": {"workers": 2, "sleep": 2.0},
 }
 
+# Default concurrency steps for calibrate mode (doubles each time)
+DEFAULT_CALIBRATE_STEPS = [1, 2, 4, 8, 16]
+DEFAULT_CALIBRATE_STEP_DURATION = 30  # seconds per concurrency level
+
 # Default model endpoint (Kubernetes service DNS name in RawDeployment mode)
 DEFAULT_URL = "http://opt-125m-predictor/openai/v1/completions"
+DEFAULT_MODEL = "opt-125m"
 DEFAULT_DURATION = 600  # 10 minutes
 DEFAULT_MAX_TOKENS = 200
 DEFAULT_PROMPT = (
@@ -61,7 +71,7 @@ DEFAULT_PROMPT = (
 )
 
 # ---------------------------------------------------------------------------
-# Globals for stats
+# Globals for stats (used by load generation modes)
 # ---------------------------------------------------------------------------
 stats_lock = threading.Lock()
 total_requests = 0
@@ -71,11 +81,11 @@ start_time: float = 0.0
 stop_event = threading.Event()
 
 
-def send_request(url: str, prompt: str, max_tokens: int) -> dict | None:
+def send_request(url: str, model: str, prompt: str, max_tokens: int) -> dict | None:
     """Send a single completion request to the vLLM endpoint."""
     payload = json.dumps(
         {
-            "model": "opt-125m",
+            "model": model,
             "prompt": prompt,
             "max_tokens": max_tokens,
         }
@@ -94,13 +104,28 @@ def send_request(url: str, prompt: str, max_tokens: int) -> dict | None:
 
 
 def worker_loop(
-    worker_id: int, url: str, prompt: str, max_tokens: int, sleep_sec: float
+    worker_id: int,
+    url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    sleep_sec: float,
+    local_stop: threading.Event | None = None,
 ):
-    """Continuously send requests with a sleep between each, until stop_event is set."""
+    """Continuously send requests with a sleep between each.
+
+    Stops when stop_event or local_stop (if given) is set.
+    In load generation modes, updates the global stats counters.
+    In calibrate mode, returns per-step counts via the return value of each
+    call — but since this runs in a thread, results are collected via the
+    shared calibrate_step_* counters instead.
+    """
     global total_requests, total_tokens, total_errors
 
-    while not stop_event.is_set():
-        result = send_request(url, prompt, max_tokens)
+    stopper = local_stop if local_stop is not None else stop_event
+
+    while not stopper.is_set() and not stop_event.is_set():
+        result = send_request(url, model, prompt, max_tokens)
 
         with stats_lock:
             if result and "usage" in result:
@@ -109,13 +134,12 @@ def worker_loop(
             else:
                 total_errors += 1
 
-        # Sleep between requests (interruptible via stop_event)
-        if sleep_sec > 0 and not stop_event.is_set():
-            stop_event.wait(timeout=sleep_sec)
+        if sleep_sec > 0 and not stopper.is_set():
+            stopper.wait(timeout=sleep_sec)
 
 
 def print_stats():
-    """Periodically print throughput stats."""
+    """Periodically print cumulative throughput stats (load generation modes)."""
     while not stop_event.is_set():
         stop_event.wait(timeout=10)
         if stop_event.is_set():
@@ -131,19 +155,189 @@ def print_stats():
             )
 
 
+# ---------------------------------------------------------------------------
+# Calibrate mode helpers
+# ---------------------------------------------------------------------------
+
+
+def metrics_url_from_completions_url(completions_url: str) -> str:
+    """Derive the /metrics URL from the completions endpoint URL.
+
+    e.g. http://opt-125m-predictor/openai/v1/completions
+      -> http://opt-125m-predictor/metrics
+    """
+    parsed = urlparse(completions_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{base}/metrics"
+
+
+def fetch_metrics(metrics_url: str) -> str:
+    """Fetch the raw Prometheus metrics text from the vLLM endpoint."""
+    try:
+        with urllib.request.urlopen(metrics_url, timeout=10) as resp:
+            return resp.read().decode("utf-8")
+    except (urllib.error.URLError, OSError):
+        return ""
+
+
+def parse_metric(metrics_text: str, prefix: str) -> float:
+    """Extract the value of the first metric line starting with prefix."""
+    for line in metrics_text.splitlines():
+        if line.startswith(prefix) and not line.startswith("# "):
+            try:
+                return float(line.split()[-1])
+            except ValueError:
+                pass
+    return 0.0
+
+
+def snapshot_metrics(metrics_url: str) -> dict:
+    """Return a snapshot of the counters needed for calibration."""
+    text = fetch_metrics(metrics_url)
+    return {
+        "prompt_tokens": parse_metric(text, "vllm:prompt_tokens_total{"),
+        "generation_tokens": parse_metric(text, "vllm:generation_tokens_total{"),
+        "latency_count": parse_metric(text, "vllm:e2e_request_latency_seconds_count{"),
+        "latency_sum": parse_metric(text, "vllm:e2e_request_latency_seconds_sum{"),
+    }
+
+
+def run_calibrate(args: argparse.Namespace) -> None:
+    """Step through concurrency levels and print a throughput/latency table."""
+    global total_requests, total_tokens, total_errors
+
+    m_url = metrics_url_from_completions_url(args.url)
+
+    steps = DEFAULT_CALIBRATE_STEPS
+    step_duration = DEFAULT_CALIBRATE_STEP_DURATION
+
+    print("=== vLLM single-replica throughput calibration ===")
+    print(f"  URL:        {args.url}")
+    print(f"  Model:      {args.model}")
+    print(f"  Metrics:    {m_url}")
+    print(f"  Duration:   {step_duration}s per concurrency step")
+    print(f"  Max tokens: {args.max_tokens}")
+    print()
+    print("Make sure only ONE replica is running and there is no other traffic.")
+    print("The ScaledObject (if deployed) should be deleted or paused first.")
+    print()
+
+    # Verify metrics are reachable
+    test = fetch_metrics(m_url)
+    if not test:
+        print(f"ERROR: could not reach metrics endpoint at {m_url}")
+        print(
+            "Check that the service URL is correct and reachable from this pod/notebook."
+        )
+        return
+
+    print(
+        f"  {'Concurrency':<12} {'Throughput (tok/s)':<22} {'Mean latency (s)':<20} Note"
+    )
+    print(
+        f"  {'-----------':<12} {'------------------':<22} {'----------------':<20} ----"
+    )
+
+    prev_rate: float = 0.0
+    best_rate: float = 0.0  # last rate before a plateau was detected
+
+    for concurrency in steps:
+        # Snapshot before
+        snap_before = snapshot_metrics(m_url)
+        t0 = time.time()
+
+        # Run load for step_duration seconds using a per-step stop event
+        step_stop = threading.Event()
+        threads = []
+        # Reset per-step counters
+        with stats_lock:
+            total_requests = 0
+            total_tokens = 0
+            total_errors = 0
+
+        for _ in range(concurrency):
+            t = threading.Thread(
+                target=worker_loop,
+                args=(
+                    0,
+                    args.url,
+                    args.model,
+                    args.prompt,
+                    args.max_tokens,
+                    0.0,
+                    step_stop,
+                ),
+                daemon=True,
+            )
+            t.start()
+            threads.append(t)
+
+        step_stop.wait(timeout=step_duration)
+        step_stop.set()
+        for t in threads:
+            t.join(timeout=10)
+
+        elapsed = time.time() - t0
+
+        # Snapshot after (for latency delta only)
+        snap_after = snapshot_metrics(m_url)
+
+        # Throughput: derived from response bodies (exact), not /metrics counters.
+        # The global total_tokens counter was reset at step start and incremented
+        # by worker_loop for every completed request within this step.
+        with stats_lock:
+            step_tokens = total_tokens
+            step_errors = total_errors
+        rate = step_tokens / elapsed if elapsed > 0 else 0.0
+
+        delta_count = snap_after["latency_count"] - snap_before["latency_count"]
+        delta_sum = snap_after["latency_sum"] - snap_before["latency_sum"]
+        mean_lat = f"{delta_sum / delta_count:.2f}" if delta_count > 0 else "n/a"
+
+        # Flag plateau: throughput grew less than 15% despite adding concurrency
+        note = ""
+        plateau = prev_rate > 0 and (rate - prev_rate) / prev_rate < 0.15
+        if plateau:
+            note = "<-- plateau, saturation likely here"
+        else:
+            best_rate = rate  # still growing — update best
+
+        err_note = f" ({step_errors} errors)" if step_errors else ""
+        print(f"  {concurrency:<12} {rate:<22.1f} {mean_lat:<20} {note}{err_note}")
+        prev_rate = rate
+
+        # Stop early once clearly saturated
+        if plateau and concurrency >= 4:
+            break
+
+    print()
+    print("Find the last step where throughput was still growing.")
+    print("Set your KEDA threshold to ~80% of its tok/s value.")
+    print()
+    threshold_suggestion = math.floor(best_rate * 0.8) if best_rate > 0 else "?"
+    print(
+        f"  Suggested threshold (80% of last pre-plateau rate): {threshold_suggestion} tok/s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
 def main():
     global start_time
 
     parser = argparse.ArgumentParser(
-        description="Load generator for KServe + KEDA autoscaling demo",
+        description="Load generator and calibration tool for KServe + KEDA autoscaling",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
     parser.add_argument(
         "--mode",
-        choices=["stable-2", "stable-3", "custom"],
+        choices=["stable-2", "stable-3", "custom", "calibrate"],
         default="stable-2",
-        help="Load preset (default: stable-2)",
+        help="Mode to run (default: stable-2)",
     )
     parser.add_argument(
         "--workers",
@@ -160,13 +354,18 @@ def main():
     parser.add_argument(
         "--url",
         default=DEFAULT_URL,
-        help=f"Service URL (default: {DEFAULT_URL})",
+        help=f"Completions endpoint URL (default: {DEFAULT_URL})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Model name to use in requests (default: {DEFAULT_MODEL})",
     )
     parser.add_argument(
         "--duration",
         type=int,
         default=DEFAULT_DURATION,
-        help=f"Duration in seconds (default: {DEFAULT_DURATION})",
+        help=f"Duration in seconds for load modes (default: {DEFAULT_DURATION})",
     )
     parser.add_argument(
         "--max-tokens",
@@ -182,7 +381,19 @@ def main():
 
     args = parser.parse_args()
 
-    # Resolve configuration
+    # ---------------------------------------------------------------------------
+    # Calibrate mode — separate path, no global stat loop
+    # ---------------------------------------------------------------------------
+    if args.mode == "calibrate":
+        signal.signal(
+            signal.SIGINT, lambda s, f: (print("\nInterrupted."), stop_event.set())
+        )
+        run_calibrate(args)
+        return
+
+    # ---------------------------------------------------------------------------
+    # Load generation modes
+    # ---------------------------------------------------------------------------
     if args.mode == "custom":
         if args.workers is None or args.sleep is None:
             parser.error("--workers and --sleep are required in custom mode")
@@ -194,17 +405,17 @@ def main():
         sleep_sec = args.sleep if args.sleep is not None else preset["sleep"]
 
     print("=== Load Generator ===")
-    print(f"  Mode:      {args.mode}")
-    print(f"  Workers:   {workers}")
-    print(f"  Sleep:     {sleep_sec}s between requests")
-    print(f"  URL:       {args.url}")
-    print(f"  Duration:  {args.duration}s")
+    print(f"  Mode:       {args.mode}")
+    print(f"  Workers:    {workers}")
+    print(f"  Sleep:      {sleep_sec}s between requests")
+    print(f"  URL:        {args.url}")
+    print(f"  Model:      {args.model}")
+    print(f"  Duration:   {args.duration}s")
     print(f"  Max tokens: {args.max_tokens}")
     print()
     print("Starting load... (Ctrl+C to stop)")
     print()
 
-    # Handle Ctrl+C gracefully
     def signal_handler(sig, frame):
         print("\n\nStopping load...")
         stop_event.set()
@@ -214,22 +425,19 @@ def main():
 
     start_time = time.time()
 
-    # Start stats printer
     stats_thread = threading.Thread(target=print_stats, daemon=True)
     stats_thread.start()
 
-    # Start worker threads
     threads = []
     for i in range(workers):
         t = threading.Thread(
             target=worker_loop,
-            args=(i, args.url, args.prompt, args.max_tokens, sleep_sec),
+            args=(i, args.url, args.model, args.prompt, args.max_tokens, sleep_sec),
             daemon=True,
         )
         t.start()
         threads.append(t)
 
-    # Wait for duration or Ctrl+C
     try:
         stop_event.wait(timeout=args.duration)
     except KeyboardInterrupt:
@@ -237,11 +445,9 @@ def main():
 
     stop_event.set()
 
-    # Wait for threads to finish
     for t in threads:
         t.join(timeout=5)
 
-    # Final stats
     elapsed = time.time() - start_time
     with stats_lock:
         tok_rate = total_tokens / elapsed if elapsed > 0 else 0

--- a/serving/kserve-keda-autoscaling/load-generator.py
+++ b/serving/kserve-keda-autoscaling/load-generator.py
@@ -65,12 +65,12 @@ DEFAULT_PROMPT = (
 # ---------------------------------------------------------------------------
 # Globals for stats (used by load generation modes)
 # ---------------------------------------------------------------------------
-stats_lock = threading.Lock()
-total_requests = 0
-total_tokens = 0
-total_errors = 0
-start_time: float = 0.0
-stop_event = threading.Event()
+STATS_LOCK = threading.Lock()
+TOTAL_REQUESTS = 0
+TOTAL_TOKENS = 0
+TOTAL_ERRORS = 0
+START_TIME: float = 0.0
+STOP_EVENT = threading.Event()
 
 
 def send_request(url: str, model: str, prompt: str, max_tokens: int) -> dict | None:
@@ -104,17 +104,17 @@ def worker_loop(
     stop: threading.Event,
 ):
     """Continuously send requests with a sleep between each."""
-    global total_requests, total_tokens, total_errors
+    global TOTAL_REQUESTS, TOTAL_TOKENS, TOTAL_ERRORS
 
     while not stop.is_set():
         result = send_request(url, model, prompt, max_tokens)
 
-        with stats_lock:
+        with STATS_LOCK:
             if result and "usage" in result:
-                total_requests += 1
-                total_tokens += result["usage"].get("total_tokens", 0)
+                TOTAL_REQUESTS += 1
+                TOTAL_TOKENS += result["usage"].get("total_tokens", 0)
             else:
-                total_errors += 1
+                TOTAL_ERRORS += 1
 
         if sleep_sec > 0 and not stop.is_set():
             stop.wait(timeout=sleep_sec)
@@ -122,17 +122,17 @@ def worker_loop(
 
 def print_stats():
     """Periodically print cumulative throughput stats (load generation modes)."""
-    while not stop_event.is_set():
-        stop_event.wait(timeout=10)
-        if stop_event.is_set():
+    while not STOP_EVENT.is_set():
+        STOP_EVENT.wait(timeout=10)
+        if STOP_EVENT.is_set():
             break
-        elapsed = time.time() - start_time
-        with stats_lock:
-            tok_rate = total_tokens / elapsed if elapsed > 0 else 0
-            req_rate = total_requests / elapsed if elapsed > 0 else 0
+        elapsed = time.time() - START_TIME
+        with STATS_LOCK:
+            tok_rate = TOTAL_TOKENS / elapsed if elapsed > 0 else 0
+            req_rate = TOTAL_REQUESTS / elapsed if elapsed > 0 else 0
             print(
-                f"  [{elapsed:6.0f}s] requests={total_requests}  "
-                f"tokens={total_tokens}  errors={total_errors}  "
+                f"  [{elapsed:6.0f}s] requests={TOTAL_REQUESTS}  "
+                f"tokens={TOTAL_TOKENS}  errors={TOTAL_ERRORS}  "
                 f"avg_tok/s={tok_rate:.1f}  avg_req/s={req_rate:.2f}"
             )
 
@@ -143,7 +143,7 @@ def print_stats():
 
 
 def main():
-    global start_time
+    global START_TIME
 
     parser = argparse.ArgumentParser(
         description="Load generator for KServe + KEDA autoscaling",
@@ -223,20 +223,20 @@ def main():
     print("Starting load... (Ctrl+C to stop)")
     print()
 
-    def signal_handler(sig, frame):
+    def signal_handler(_sig, _frame):
         print("\n\nStopping load...")
-        stop_event.set()
+        STOP_EVENT.set()
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    start_time = time.time()
+    START_TIME = time.time()
 
     stats_thread = threading.Thread(target=print_stats, daemon=True)
     stats_thread.start()
 
     threads = []
-    for i in range(workers):
+    for _ in range(workers):
         t = threading.Thread(
             target=worker_loop,
             args=(
@@ -245,7 +245,7 @@ def main():
                 args.prompt,
                 args.max_tokens,
                 sleep_sec,
-                stop_event,
+                STOP_EVENT,
             ),
             daemon=True,
         )
@@ -253,26 +253,26 @@ def main():
         threads.append(t)
 
     try:
-        stop_event.wait(timeout=args.duration)
+        STOP_EVENT.wait(timeout=args.duration)
     except KeyboardInterrupt:
         pass
 
-    stop_event.set()
+    STOP_EVENT.set()
 
     for t in threads:
         t.join(timeout=5)
 
-    elapsed = time.time() - start_time
-    with stats_lock:
-        tok_rate = total_tokens / elapsed if elapsed > 0 else 0
-        req_rate = total_requests / elapsed if elapsed > 0 else 0
+    elapsed = time.time() - START_TIME
+    with STATS_LOCK:
+        tok_rate = TOTAL_TOKENS / elapsed if elapsed > 0 else 0
+        req_rate = TOTAL_REQUESTS / elapsed if elapsed > 0 else 0
 
     print()
     print("=== Final Stats ===")
     print(f"  Duration:   {elapsed:.1f}s")
-    print(f"  Requests:   {total_requests}")
-    print(f"  Tokens:     {total_tokens}")
-    print(f"  Errors:     {total_errors}")
+    print(f"  Requests:   {TOTAL_REQUESTS}")
+    print(f"  Tokens:     {TOTAL_TOKENS}")
+    print(f"  Errors:     {TOTAL_ERRORS}")
     print(f"  Avg tok/s:  {tok_rate:.1f}")
     print(f"  Avg req/s:  {req_rate:.2f}")
 


### PR DESCRIPTION
## Summary

- Adds a `calibrate.py` script that steps through increasing concurrency levels, measures token throughput and mean end-to-end latency per step, detects a saturation plateau, and suggests a KEDA threshold at 80% of the pre-plateau rate.
- Documents the calibration workflow in the README with step-by-step instructions (delete ScaledObject, scale to 1 replica, run calibration, re-apply ScaledObject).
- Adds a concise CPU vs GPU note explaining that GPU deployments produce a clear plateau while CPU deployments may not, and that the `threshold: "5"` in the example is a demo value.
- Exposes `--model` as a CLI argument so scripts work with any model name, not just `opt-125m`.

## Changes from review feedback

**Split calibrate into a standalone script** (per @Korel): calibration logic is now in `calibrate.py` rather than a `--mode calibrate` flag on `load-generator.py`. The two scripts have different concerns (sustained load vs. stepped measurement), different dependencies (`urlparse`, `math`, Prometheus scraping), and different control flows — splitting restores `load-generator.py` to its original simplicity and lets `calibrate.py` own its metrics/plateau logic without compromise.

The split also enabled a cleaner internal design: `calibrate.py` uses per-step local state (`totals` dict + lock) instead of resetting shared globals, and the `local_stop`/dual-stop-event hack in `worker_loop` is gone entirely. Shared code (`send_request`, ~15 lines) is duplicated — preferable to coupling the two programs at the module level.

`calibrate.py` also gains `KeyboardInterrupt` handling: Ctrl+C mid-step stops workers, then still prints the partial table and threshold suggestion.