### PR TITLE
fix: set VLLM_CPU_KVCACHE_SPACE to prevent OOM on CPU deployments

### DIFF
--- a/serving/kserve-keda-autoscaling/inference-service.yaml
+++ b/serving/kserve-keda-autoscaling/inference-service.yaml
@@ -25,6 +25,13 @@ spec:
         - --backend=vllm
         - --dtype=float32
         - --max-model-len=512
+      env:
+        # vLLM CPU defaults to using all available memory for the KV cache,
+        # which will OOM the container. Set an explicit budget (in GiB) that
+        # fits within the memory limit below, leaving headroom for model weights
+        # and runtime overhead.
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: "4"
       # Explicit port declaration is required in RawDeployment mode
       # for the cluster-wide PodMonitor to discover the metrics endpoint.
       ports:


### PR DESCRIPTION
## Summary

- Without `VLLM_CPU_KVCACHE_SPACE` set, vLLM defaults to allocating all available node memory for the KV cache, immediately OOMKilling the predictor container on CPU deployments.
- Sets an explicit 4 GiB budget, which fits comfortably within the 8Gi memory limit while leaving headroom for model weights (~500 MB for OPT-125M) and runtime overhead.