### PR TITLE
Add storage examples for databases and s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For full platform documentation, see [docs.prokube.ai](https://docs.prokube.ai/)
 ├── pipelines        # Kubeflow Pipelines examples
 ├── rstudio          # RStudio examples
 ├── serving          # model serving examples (KServe, vLLM, shadow deployments)
+├── storage          # object storage and database access examples
 ```
 
 ## Note about storage
@@ -34,6 +35,8 @@ to use other instances of object storage (e.g. self-hosted S3-compatible storage
 Many S3 libraries use environment variables for their configuration — those are usually:
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `S3_ENDPOINT`. They are likely already
 available in your environment. You can also ask your admin about them.
+
+See `storage/s3` for S3 examples and `storage/database-access` for relational database examples in Python and R.
 
 ## Platform compatibility
 

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,0 +1,8 @@
+# Storage Examples
+
+This directory contains examples for accessing storage services from prokube labs.
+
+- `s3`: read and write data with S3-compatible object storage.
+- `database-access`: connect to PostgreSQL, MariaDB/MySQL, and SQL Server-compatible databases.
+
+The examples are available for Python notebooks and RStudio. They use the packages already provided by the pk notebook and pk RStudio images.

--- a/storage/database-access/README.md
+++ b/storage/database-access/README.md
@@ -1,0 +1,38 @@
+# Database Access
+
+These examples show how to connect from the pk notebook and pk RStudio images to common relational databases.
+
+The pk notebook and pk RStudio images already include the required ODBC drivers and language packages. Each example uses the Iris dataset, creates a table named `iris_example`, writes the data, reads a few rows back, and closes the connection.
+
+## Examples
+
+- PostgreSQL: `python/postgresql.ipynb`, `r/postgresql.R`
+- MariaDB/MySQL: `python/mariadb.ipynb`, `r/mariadb.R`
+- Microsoft SQL Server: `python/sqlserver.ipynb`, `r/sqlserver.R`
+
+Edit only the connection values at the top of the example you want to run:
+
+- `host`
+- `port`
+- `database`
+- `user`
+
+The examples prompt for the password.
+
+## Drivers
+
+The Python notebooks use these database drivers:
+
+- PostgreSQL: `psycopg2`
+- MariaDB/MySQL: `pyodbc` with `MariaDB Unicode`
+- Microsoft SQL Server: `pyodbc` with `FreeTDS`
+
+The R scripts use `DBI` and `odbc` with the same ODBC drivers.
+
+## Microsoft SQL Server
+
+For Microsoft SQL servers you first need to find out which port the server is using. Open a terminal in RStudio and run:
+
+```sh
+tsql -L -H <server-domain>
+```

--- a/storage/database-access/python/duckdb.ipynb
+++ b/storage/database-access/python/duckdb.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "250f9140",
+   "metadata": {},
+   "source": [
+    "## DuckDB\n",
+    "DuckDB can read files from S3-backed storage through its `httpfs` extension. In managed Labs, S3-compatible endpoint and credential environment variables are usually provided by the workspace configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b98f465",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install duckdb\n",
+    "!pip install duckdb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ba83c11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "import os \n",
+    "\n",
+    "conn = duckdb.connect()\n",
+    "conn.execute(\"INSTALL httpfs\")\n",
+    "conn.execute(\"LOAD httpfs\")\n",
+    "conn.execute(\"SET s3_url_style='path'\")\n",
+    "conn.execute(f\"SET s3_endpoint='{os.environ['S3_ENDPOINT']}'\")\n",
+    "conn.execute(f\"SET s3_use_ssl = {'false' if os.environ['S3_USE_HTTPS'] == '0' else 'true'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d990fd48",
+   "metadata": {},
+   "source": [
+    "To check whether DuckDB can discover credentials in the current environment, run `CALL load_aws_credentials()` after loading the `httpfs` extension."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d7c6b5a",
+   "metadata": {},
+   "source": [
+    "## Iris dataset in S3 Parquet\n",
+    "\n",
+    "Write the Iris dataset to an S3-backed Parquet file and read it back with DuckDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f5e4d3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "\n",
+    "bucket = \"<bucketname>\"\n",
+    "key = \"storage-examples/iris.parquet\"\n",
+    "\n",
+    "if not bucket or bucket == \"<bucketname>\":\n",
+    "    raise ValueError(\"Set bucket to your S3 bucket name.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b1a0f9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iris = load_iris(as_frame=True).frame\n",
+    "s3_path = f\"s3://{bucket}/{key}\"\n",
+    "\n",
+    "conn.register(\"iris\", iris)\n",
+    "conn.execute(\n",
+    "    f\"COPY iris TO '{s3_path}' (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)\"\n",
+    ")\n",
+    "\n",
+    "read_back = conn.sql(f\"SELECT * FROM read_parquet('{s3_path}')\").df()\n",
+    "read_back.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/storage/database-access/python/mariadb.ipynb
+++ b/storage/database-access/python/mariadb.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "812eb55e",
+   "metadata": {},
+   "source": [
+    "# MariaDB/MySQL Access\n",
+    "\n",
+    "Write the Iris dataset to MariaDB or MySQL and read it back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db21f0c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.datasets import load_iris"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90a6af60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "host = \"<server-domain>\"\n",
+    "port = 3306\n",
+    "database = \"<database>\"\n",
+    "user = \"<user>\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3100e7e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = load_iris(as_frame=True)\n",
+    "df.frame.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "502ba2cb",
+   "metadata": {},
+   "source": [
+    "## SQLAlchemy \n",
+    "[SQLAlchemy](https://www.sqlalchemy.org/) is a Python library that provides a database abstraction layer so you can connect to different SQL databases.\n",
+    "It works well with `pandas.to_sql()` and `pandas.read_sql()` and can be used with different backends.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a328ba04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import URL, create_engine\n",
+    "\n",
+    "engine = create_engine(\n",
+    "    URL.create(\n",
+    "        \"mysql+pyodbc\",\n",
+    "        username=user,\n",
+    "        password=getpass.getpass(\"Database password: \"),\n",
+    "        host=host,\n",
+    "        port=port,\n",
+    "        database=database,\n",
+    "        query={\"driver\": \"MariaDB Unicode\"},\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "df.frame.to_sql(\"iris_example\", engine, if_exists=\"replace\", index=False)\n",
+    "\n",
+    "pd.read_sql(\"SELECT * FROM iris_example\", engine).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0ebb300",
+   "metadata": {},
+   "source": [
+    "## pyodbc cursor\n",
+    "\n",
+    "Direct `pyodbc` cursor calls are more verbose, but they show the underlying DB-API flow: open a connection, create a cursor, execute SQL, commit, fetch rows, and close the connection.\n",
+    "\n",
+    "Documentation: [pyodbc](https://github.com/mkleehammer/pyodbc/wiki)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f34c3be1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyodbc\n",
+    "\n",
+    "conn = pyodbc.connect(\n",
+    "    \"DRIVER={MariaDB Unicode};\"\n",
+    "    f\"SERVER={host};\"\n",
+    "    f\"PORT={port};\"\n",
+    "    f\"DATABASE={database};\"\n",
+    "    f\"UID={user};\"\n",
+    "    f\"PWD={getpass.getpass('Database password: ')}\"\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    cursor = conn.cursor()\n",
+    "    cursor.execute(\"DROP TABLE IF EXISTS iris_example_cursor\")\n",
+    "    cursor.execute(\"\"\"\n",
+    "        CREATE TABLE iris_example_cursor (\n",
+    "            `sepal length (cm)` DOUBLE,\n",
+    "            `sepal width (cm)` DOUBLE,\n",
+    "            `petal length (cm)` DOUBLE,\n",
+    "            `petal width (cm)` DOUBLE,\n",
+    "            target INTEGER\n",
+    "        )\n",
+    "    \"\"\")\n",
+    "    cursor.executemany(\"\"\"\n",
+    "        INSERT INTO iris_example_cursor (\n",
+    "            `sepal length (cm)`,\n",
+    "            `sepal width (cm)`,\n",
+    "            `petal length (cm)`,\n",
+    "            `petal width (cm)`,\n",
+    "            target\n",
+    "        )\n",
+    "        VALUES (?, ?, ?, ?, ?)\n",
+    "    \"\"\", df.frame.itertuples(index=False, name=None))\n",
+    "    conn.commit()\n",
+    "\n",
+    "    cursor.execute(\"SELECT * FROM iris_example_cursor LIMIT 5\")\n",
+    "    rows = cursor.fetchall()\n",
+    "    columns = [column[0] for column in cursor.description]\n",
+    "    display(pd.DataFrame.from_records(rows, columns=columns))\n",
+    "finally:\n",
+    "    conn.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/storage/database-access/python/postgresql.ipynb
+++ b/storage/database-access/python/postgresql.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f3000bce",
+   "metadata": {},
+   "source": [
+    "# PostgreSQL Access\n",
+    "\n",
+    "Write the Iris dataset to PostgreSQL and read it back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0b806c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.datasets import load_iris"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca059a31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "host = \"<server-domain>\"\n",
+    "port = 5432\n",
+    "database = \"<database>\"\n",
+    "user = \"<user>\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d97f6e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = load_iris(as_frame=True)\n",
+    "df.frame.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c1bc368",
+   "metadata": {},
+   "source": [
+    "## SQLAlchemy \n",
+    "[SQLAlchemy](https://www.sqlalchemy.org/) is a Python library that provides a database abstraction layer so you can connect to different SQL databases.\n",
+    "It works well with `pandas.to_sql()` and `pandas.read_sql()` and can be used with different backends.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f48e4486",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import URL, create_engine\n",
+    "\n",
+    "engine = create_engine(\n",
+    "    URL.create(\n",
+    "        \"postgresql+psycopg2\",\n",
+    "        username=user,\n",
+    "        password=getpass.getpass(\"Database password: \"),\n",
+    "        host=host,\n",
+    "        port=port,\n",
+    "        database=database,\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "df.frame.to_sql(\"iris_example\", engine, if_exists=\"replace\", index=False)\n",
+    "pd.read_sql(\"SELECT * FROM iris_example\", engine).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fa69e55",
+   "metadata": {},
+   "source": [
+    "## psycopg2 cursor\n",
+    "\n",
+    "Direct `psycopg2` cursor calls are more verbose, but they show the underlying DB-API flow: open a connection, create a cursor, execute SQL, commit, fetch rows, and close the connection.\n",
+    "\n",
+    "Documentation: [psycopg2](https://www.psycopg.org/docs/index.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "859cbf65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import psycopg2\n",
+    "\n",
+    "conn = psycopg2.connect(\n",
+    "    host=host,\n",
+    "    port=port,\n",
+    "    dbname=database,\n",
+    "    user=user,\n",
+    "    password=getpass.getpass(\"Database password: \"),\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    with conn.cursor() as cursor:\n",
+    "        cursor.execute(\"DROP TABLE IF EXISTS iris_example_cursor\")\n",
+    "        cursor.execute(\"\"\"\n",
+    "            CREATE TABLE iris_example_cursor (\n",
+    "                \"sepal length (cm)\" DOUBLE PRECISION,\n",
+    "                \"sepal width (cm)\" DOUBLE PRECISION,\n",
+    "                \"petal length (cm)\" DOUBLE PRECISION,\n",
+    "                \"petal width (cm)\" DOUBLE PRECISION,\n",
+    "                target INTEGER\n",
+    "            )\n",
+    "        \"\"\")\n",
+    "        cursor.executemany(\"\"\"\n",
+    "            INSERT INTO iris_example_cursor (\n",
+    "                \"sepal length (cm)\",\n",
+    "                \"sepal width (cm)\",\n",
+    "                \"petal length (cm)\",\n",
+    "                \"petal width (cm)\",\n",
+    "                target\n",
+    "            )\n",
+    "            VALUES (%s, %s, %s, %s, %s)\n",
+    "        \"\"\", df.frame.itertuples(index=False, name=None))\n",
+    "        conn.commit()\n",
+    "\n",
+    "        cursor.execute(\"SELECT * FROM iris_example_cursor LIMIT 5\")\n",
+    "        rows = cursor.fetchall()\n",
+    "        columns = [column.name for column in cursor.description]\n",
+    "\n",
+    "    display(pd.DataFrame(rows, columns=columns))\n",
+    "finally:\n",
+    "    conn.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/storage/database-access/python/sqlserver.ipynb
+++ b/storage/database-access/python/sqlserver.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe5bb86e",
+   "metadata": {},
+   "source": [
+    "# Microsoft SQL Server Access\n",
+    "\n",
+    "Write the Iris dataset to Microsoft SQL Server through FreeTDS and read it back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b494a5d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.datasets import load_iris"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53c44dcc",
+   "metadata": {},
+   "source": [
+    "If you do not know the SQL Server port, open a terminal in RStudio and run `tsql -L -H <server-domain>`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc56b6ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "host = \"<server-domain>\"\n",
+    "port = 1433\n",
+    "database = \"<database>\"\n",
+    "user = \"<user>\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb4a444e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = load_iris(as_frame=True)\n",
+    "df.frame.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc290b98",
+   "metadata": {},
+   "source": [
+    "## SQLAlchemy \n",
+    "[SQLAlchemy](https://www.sqlalchemy.org/) is a Python library that provides a database abstraction layer so you can connect to different SQL databases.\n",
+    "It works well with `pandas.to_sql()` and `pandas.read_sql()` and can be used with different backends.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cce8a9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import URL, create_engine\n",
+    "\n",
+    "engine = create_engine(\n",
+    "    URL.create(\n",
+    "        \"mssql+pyodbc\",\n",
+    "        username=user,\n",
+    "        password=getpass.getpass(\"Database password: \"),\n",
+    "        host=host,\n",
+    "        port=port,\n",
+    "        database=database,\n",
+    "        query={\"driver\": \"FreeTDS\", \"TDS_Version\": \"7.4\"},\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "df.frame.to_sql(\"iris_example\", engine, if_exists=\"replace\", index=False)\n",
+    "pd.read_sql(\"SELECT * FROM iris_example\", engine).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5919940",
+   "metadata": {},
+   "source": [
+    "## pyodbc cursor\n",
+    "\n",
+    "Direct `pyodbc` cursor calls are more verbose, but they show the underlying DB-API flow: open a connection, create a cursor, execute SQL, commit, fetch rows, and close the connection.\n",
+    "\n",
+    "Documentation: [pyodbc](https://github.com/mkleehammer/pyodbc/wiki)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d110276",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyodbc\n",
+    "\n",
+    "conn = pyodbc.connect(\n",
+    "    \"DRIVER={FreeTDS};\"\n",
+    "    f\"SERVER={host};\"\n",
+    "    f\"PORT={port};\"\n",
+    "    f\"DATABASE={database};\"\n",
+    "    f\"UID={user};\"\n",
+    "    f\"PWD={getpass.getpass('Database password: ')};\"\n",
+    "    \"TDS_Version=7.4\"\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    cursor = conn.cursor()\n",
+    "    cursor.execute(\"DROP TABLE IF EXISTS iris_example_cursor\")\n",
+    "    cursor.execute(\"\"\"\n",
+    "        CREATE TABLE iris_example_cursor (\n",
+    "            [sepal length (cm)] FLOAT,\n",
+    "            [sepal width (cm)] FLOAT,\n",
+    "            [petal length (cm)] FLOAT,\n",
+    "            [petal width (cm)] FLOAT,\n",
+    "            target INTEGER\n",
+    "        )\n",
+    "    \"\"\")\n",
+    "    cursor.executemany(\"\"\"\n",
+    "        INSERT INTO iris_example_cursor (\n",
+    "            [sepal length (cm)],\n",
+    "            [sepal width (cm)],\n",
+    "            [petal length (cm)],\n",
+    "            [petal width (cm)],\n",
+    "            target\n",
+    "        )\n",
+    "        VALUES (?, ?, ?, ?, ?)\n",
+    "    \"\"\", df.frame.itertuples(index=False, name=None))\n",
+    "    conn.commit()\n",
+    "\n",
+    "    cursor.execute(\"SELECT TOP 5 * FROM iris_example_cursor\")\n",
+    "    rows = cursor.fetchall()\n",
+    "    columns = [column[0] for column in cursor.description]\n",
+    "    display(pd.DataFrame.from_records(rows, columns=columns))\n",
+    "finally:\n",
+    "    conn.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/storage/database-access/r/mariadb.R
+++ b/storage/database-access/r/mariadb.R
@@ -1,0 +1,26 @@
+library(DBI)
+library(odbc)
+library(rstudioapi)
+
+host <- "<server-domain>"
+port <- 3306
+database <- "<database>"
+user <- "<user>"
+password <- askForPassword("Database password")
+
+con <- dbConnect(
+  odbc(),
+  Driver = "MariaDB Unicode",
+  Server = host,
+  Port = port,
+  Database = database,
+  UID = user,
+  PWD = password
+)
+
+tryCatch({
+  dbWriteTable(con, "iris_example", iris, overwrite = TRUE, row.names = FALSE)
+  print(head(dbReadTable(con, "iris_example")))
+}, finally = {
+  dbDisconnect(con)
+})

--- a/storage/database-access/r/postgresql.R
+++ b/storage/database-access/r/postgresql.R
@@ -1,0 +1,26 @@
+library(DBI)
+library(odbc)
+library(rstudioapi)
+
+host <- "<server-domain>"
+port <- 5432
+database <- "<database>"
+user <- "<user>"
+password <- askForPassword("Database password")
+
+con <- dbConnect(
+  odbc(),
+  Driver = "PostgreSQL Unicode",
+  Server = host,
+  Port = port,
+  Database = database,
+  UID = user,
+  PWD = password
+)
+
+tryCatch({
+  dbWriteTable(con, "iris_example", iris, overwrite = TRUE, row.names = FALSE)
+  print(head(dbReadTable(con, "iris_example")))
+}, finally = {
+  dbDisconnect(con)
+})

--- a/storage/database-access/r/sqlserver.R
+++ b/storage/database-access/r/sqlserver.R
@@ -1,0 +1,29 @@
+library(DBI)
+library(odbc)
+library(rstudioapi)
+
+# If you do not know the port, run this in a terminal:
+# tsql -L -H <server-domain>
+host <- "<server-domain>"
+port <- 1433
+database <- "<database>"
+user <- "<user>"
+password <- askForPassword("Database password")
+
+con <- dbConnect(
+  odbc(),
+  Driver = "FreeTDS",
+  Server = host,
+  Port = port,
+  Database = database,
+  UID = user,
+  PWD = password,
+  TDS_Version = "7.4"
+)
+
+tryCatch({
+  dbWriteTable(con, "iris_example", iris, overwrite = TRUE, row.names = FALSE)
+  print(head(dbReadTable(con, "iris_example")))
+}, finally = {
+  dbDisconnect(con)
+})

--- a/storage/s3/README.md
+++ b/storage/s3/README.md
@@ -1,0 +1,25 @@
+# S3 Object Storage Access
+
+These examples show how to write and read the Iris dataset from prokube.ai's integrated S3 object storage.
+You only need to set the bucket name in the example.
+
+## Python
+
+Open `python/s3_access.ipynb` in a pk notebook.
+
+The notebook uses the platform configuration directly:
+
+```python
+import s3fs
+
+s3 = s3fs.S3FileSystem()
+
+with s3.open("<bucketname>/<objectname>", "rb") as f:
+    print(f.read())
+```
+
+## R
+
+Run `r/s3_access.R` in pk RStudio.
+
+The R example uses `aws.s3`. It sets `use_https = FALSE` because this example is for the preconfigured internal MinIO endpoint, where cluster traffic is protected by the platform. Do not use `use_https = FALSE` for external S3 endpoints.

--- a/storage/s3/python/s3_access.ipynb
+++ b/storage/s3/python/s3_access.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c749cac1",
+   "metadata": {},
+   "source": [
+    "# Access MinIO with Python\n",
+    "\n",
+    "Write the Iris dataset to MinIO and read it back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6452253",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import s3fs\n",
+    "from sklearn.datasets import load_iris"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ad02161",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"<bucketname>\"\n",
+    "key = \"storage-examples/iris.csv\"\n",
+    "\n",
+    "if not bucket or bucket == \"<bucketname>\":\n",
+    "    raise ValueError(\"Set bucket to your MinIO bucket name.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "437e8c92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = load_iris(as_frame=True)\n",
+    "df.frame.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f872e53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = s3fs.S3FileSystem()\n",
+    "\n",
+    "with s3.open(f\"{bucket}/{key}\", \"w\") as f:\n",
+    "    df.frame.to_csv(f, index=False)\n",
+    "\n",
+    "with s3.open(f\"{bucket}/{key}\", \"rb\") as f:\n",
+    "    read_back = pd.read_csv(f)\n",
+    "\n",
+    "read_back.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/storage/s3/r/s3_access.R
+++ b/storage/s3/r/s3_access.R
@@ -1,0 +1,30 @@
+library(aws.s3)
+
+bucket <- "<bucketname>"
+if (!nzchar(bucket) || bucket == "<bucketname>") {
+  stop("Set bucket to your S3 bucket name.", call. = FALSE)
+}
+
+key <- "storage-examples/iris.csv"
+
+csv_path <- tempfile(fileext = ".csv")
+write.csv(iris, csv_path, row.names = FALSE)
+
+put_object(
+  file = csv_path,
+  object = key,
+  bucket = bucket,
+  use_https = FALSE,
+  region = ""
+)
+
+obj <- get_object(
+  object = key,
+  bucket = bucket,
+  use_https = FALSE,
+  region = ""
+)
+
+read_back <- read.csv(text = rawToChar(obj))
+
+head(read_back)


### PR DESCRIPTION
Related to https://github.com/prokube/prokube-images/pull/56

This pull request add examples for accessing object storage and relational databases from prokube labs, including both Python and RStudio environments. It introduces a new `storage` directory with organized subfolders for S3 and database access, each containing clear, ready-to-run examples.

**New storage examples and documentation:**

* Added the `storage` directory with subfolders for S3 object storage and database access examples, including a high-level `README.md` describing their structure and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17) [[2]](diffhunk://#diff-6f5d0df1f76c52646a08fba33b565bf6a18a5463a883bccbba76ac682fb78feaR1-R8)
* Updated the main `README.md` to reference the new storage examples and clarify how to find and use them.

**S3 object storage examples:**

* Added Python (`python/s3_access.ipynb`) and R (`r/s3_access.R`) examples for reading and writing data to S3-compatible object storage, with documentation in `storage/s3/README.md`. [[1]](diffhunk://#diff-8619534a0fcae95e70de87d05312d7667deb6a7219324f35ecc54d31def4bc51R1-R25) [[2]](diffhunk://#diff-0557a29814c71773ae39e4ef91b9732d433774debd1832f2c769511133bbb053R1-R82) [[3]](diffhunk://#diff-5ec0f3bb31230ca4dc4102c082b4881cf51a3e75693bc2ed7b961920e86210a6R1-R30)

**Relational database access examples:**

* Added Python notebooks for PostgreSQL, MariaDB/MySQL, and Microsoft SQL Server, each demonstrating connection, data writing, and reading using both high-level (SQLAlchemy) and low-level (driver/cursor) approaches. [[1]](diffhunk://#diff-f4ffe52235a98b0e23e101f8e9ff10338290e315a31bfdda295efd8508aa9a05R1-R161) [[2]](diffhunk://#diff-18f0b668964372612a3d671bfc0654d700773221f4effb33138f7ee768b21b04R1-R163) [[3]](diffhunk://#diff-e3394be0be36cdd24f47250554571e4489bf18a34df79781368d4af72113e4b1R1-R171)
* Added R scripts for PostgreSQL, MariaDB/MySQL, and Microsoft SQL Server, using the `DBI` and `odbc` packages, with instructions for credential input and connection setup. [[1]](diffhunk://#diff-6e44508d54ae28c87f2468b5a51cbeb5733b32926a2a8e97cba7f25c6eb24b2eR1-R26) [[2]](diffhunk://#diff-1ea1e689f6a8e68f5c16e7b64087a6aaeca634bf1d2e86d753c30083e596f195R1-R26) [[3]](diffhunk://#diff-d515533b6b3c031243223a7126fe0c3ebd5aa929f8e18d8c1a90e0cae8d0c391R1-R29)
* Included a detailed `README.md` in `storage/database-access` explaining the examples, required drivers, and connection setup.